### PR TITLE
fix: tournament_score_rounds mongo parse util

### DIFF
--- a/src/app/(app)/commissioner/pools/[poolId]/__tests__/pool-delete-actions.test.ts
+++ b/src/app/(app)/commissioner/pools/[poolId]/__tests__/pool-delete-actions.test.ts
@@ -110,7 +110,7 @@ describe('deletePool', () => {
     formData.set('poolId', 'pool-1')
 
     await expect(deletePool(null, formData)).resolves.toEqual({
-      error: 'Only archived pools can be deleted.',
+      error: 'Only open or archived pools can be deleted.',
     })
 
     expect(deletePoolById).not.toHaveBeenCalled()

--- a/src/lib/__tests__/pool.test.ts
+++ b/src/lib/__tests__/pool.test.ts
@@ -36,7 +36,7 @@ describe('validateCreatePoolInput', () => {
       tournamentId: 't1',
       tournamentName: 'The Masters',
       year: 2026,
-      deadline: '2026-04-10T08:00:00Z',
+      deadline: '2026-04-11T08:00:00Z',
       timezone: 'America/New_York',
     })
     expect(result).toEqual({ ok: true })

--- a/src/lib/__tests__/pool.test.ts
+++ b/src/lib/__tests__/pool.test.ts
@@ -31,15 +31,22 @@ describe('generateInviteCode', () => {
 
 describe('validateCreatePoolInput', () => {
   it('returns ok for valid input', () => {
-    const result = validateCreatePoolInput({
-      name: 'Masters Pool 2026',
-      tournamentId: 't1',
-      tournamentName: 'The Masters',
-      year: 2026,
-      deadline: '2026-04-11T08:00:00Z',
-      timezone: 'America/New_York',
-    })
-    expect(result).toEqual({ ok: true })
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-09T12:00:00Z'))
+
+    try {
+      const result = validateCreatePoolInput({
+        name: 'Masters Pool 2026',
+        tournamentId: 't1',
+        tournamentName: 'The Masters',
+        year: 2026,
+        deadline: '2026-04-11T08:00:00Z',
+        timezone: 'America/New_York',
+      })
+      expect(result).toEqual({ ok: true })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('rejects empty pool name', () => {

--- a/src/lib/__tests__/scoring-queries.test.ts
+++ b/src/lib/__tests__/scoring-queries.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { upsertTournamentScore } from '../scoring-queries'
+
+describe('upsertTournamentScore', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'info').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('archives each round before writing the current score row', async () => {
+    const archiveUpserts: unknown[] = []
+    const currentUpserts: unknown[] = []
+
+    const archiveBuilder: any = {
+      upsert: vi.fn((value: unknown) => {
+        archiveUpserts.push(value)
+        return archiveBuilder
+      }),
+      then: (onFulfilled: (value: { error: null }) => unknown, onRejected?: (reason: unknown) => unknown) =>
+        Promise.resolve({ error: null }).then(onFulfilled, onRejected),
+    }
+
+    const currentBuilder: any = {
+      upsert: vi.fn((value: unknown) => {
+        currentUpserts.push(value)
+        return currentBuilder
+      }),
+      then: (onFulfilled: (value: { error: null }) => unknown, onRejected?: (reason: unknown) => unknown) =>
+        Promise.resolve({ error: null }).then(onFulfilled, onRejected),
+    }
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'tournament_score_rounds') return archiveBuilder
+        if (table === 'tournament_scores') return currentBuilder
+        throw new Error(`Unexpected table ${table}`)
+      }),
+    }
+
+    await expect(
+      upsertTournamentScore(
+        supabase as never,
+        {
+          golfer_id: 'g1',
+          tournament_id: '014',
+          total_score: -1,
+          position: 'T11',
+          total_birdies: 2,
+          status: 'active',
+        },
+        {
+          golfer_id: 'g1',
+          current_round: 2,
+          current_round_score: 1,
+          total: -1,
+          total_birdies: 2,
+          status: 'active',
+          rounds: [
+            {
+              round_id: 1,
+              strokes: 70,
+              score_to_par: -2,
+              course_id: '014',
+              course_name: 'Augusta National Golf Club',
+            },
+            {
+              round_id: 2,
+              strokes: 68,
+              score_to_par: -4,
+              course_id: '014',
+              course_name: 'Augusta National Golf Club',
+            },
+          ],
+        } as never
+      )
+    ).resolves.toEqual({ error: null })
+
+    expect(archiveUpserts).toHaveLength(2)
+    expect(archiveUpserts[0]).toMatchObject({
+      golfer_id: 'g1',
+      tournament_id: '014',
+      round_id: 1,
+      strokes: 70,
+      score_to_par: -2,
+    })
+    expect(archiveUpserts[1]).toMatchObject({
+      golfer_id: 'g1',
+      tournament_id: '014',
+      round_id: 2,
+      strokes: 68,
+      score_to_par: -4,
+    })
+    expect(currentUpserts).toHaveLength(1)
+    expect(currentUpserts[0]).toMatchObject({
+      golfer_id: 'g1',
+      tournament_id: '014',
+      round_id: 2,
+      total_score: -1,
+      status: 'active',
+    })
+  })
+})

--- a/src/lib/__tests__/scoring-refresh.test.ts
+++ b/src/lib/__tests__/scoring-refresh.test.ts
@@ -47,20 +47,36 @@ vi.mock('@/lib/scoring-queries', () => ({
 const originalEnv = { ...process.env }
 
 describe('refreshScoresForPool', () => {
+  function createMockSupabase() {
+    return {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === 'tournament_score_rounds') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ count: 0, error: null }),
+            }),
+          }
+        }
+
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+      channel: vi.fn().mockReturnValue({ send: vi.fn().mockResolvedValue(undefined) }),
+    } as unknown as never
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.spyOn(console, 'info').mockImplementation(() => undefined)
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     process.env = originalEnv
   })
 
   it('happy path: fetches scores, upserts, broadcasts, returns { data, error: null }', async () => {
     const pool = { id: 'pool-1', tournament_id: 't-1', year: 2026, status: 'live' }
-    const send = vi.fn().mockResolvedValue(undefined)
-    const mockSupabase = {
-      channel: vi.fn().mockReturnValue({ send }),
-    } as unknown as never
+    const mockSupabase = createMockSupabase()
 
     vi.mocked(getPoolsByTournament).mockResolvedValue([
       { id: 'pool-1', tournament_id: 't-1', status: 'live' },
@@ -101,7 +117,7 @@ describe('refreshScoresForPool', () => {
 
   it('external API failure: returns { data: null, error: { code: "FETCH_FAILED" } }', async () => {
     const pool = { id: 'pool-1', tournament_id: 't-1', year: 2026, status: 'live' }
-    const mockSupabase = {} as never
+    const mockSupabase = createMockSupabase()
 
     vi.mocked(getPoolsByTournament).mockResolvedValue([
       { id: 'pool-1', tournament_id: 't-1', status: 'live' },
@@ -121,7 +137,7 @@ describe('refreshScoresForPool', () => {
 
   it('upsert failure: returns { data: null, error: { code: "UPSERT_FAILED" } }', async () => {
     const pool = { id: 'pool-1', tournament_id: 't-1', year: 2026, status: 'live' }
-    const mockSupabase = {} as never
+    const mockSupabase = createMockSupabase()
 
     vi.mocked(getPoolsByTournament).mockResolvedValue([
       { id: 'pool-1', tournament_id: 't-1', status: 'live' },
@@ -145,9 +161,7 @@ describe('refreshScoresForPool', () => {
 
   it('broadcasts to all live pools on the same tournament', async () => {
     const pool = { id: 'pool-1', tournament_id: 't-1', year: 2026, status: 'live' }
-    const mockSupabase = {
-      channel: vi.fn().mockReturnValue({ send: vi.fn().mockResolvedValue(undefined) }),
-    } as never
+    const mockSupabase = createMockSupabase()
 
     vi.mocked(getPoolsByTournament).mockResolvedValue([
       { id: 'pool-1', tournament_id: 't-1', status: 'live' },

--- a/src/lib/__tests__/slash-golf-client.test.ts
+++ b/src/lib/__tests__/slash-golf-client.test.ts
@@ -111,4 +111,58 @@ describe('getTournamentScores', () => {
       ],
     })
   })
+
+  it('preserves zero values from Mongo numeric wrappers', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        orgId: '1',
+        year: '2026',
+        tournId: '014',
+        status: 'In Progress',
+        roundId: 2,
+        roundStatus: 'In Progress',
+        timestamp: '2026-04-10T15:23:33.217000',
+        leaderboardRows: [
+          {
+            lastName: 'Player',
+            firstName: 'Even',
+            isAmateur: false,
+            playerId: '99999',
+            courseId: '014',
+            status: 'active',
+            currentRound: 2,
+            total: { $numberInt: '0' },
+            currentRoundScore: { $numberInt: '0' },
+            position: 'T1',
+            totalStrokesFromCompletedRounds: '72',
+            roundComplete: false,
+            rounds: [
+              {
+                scoreToPar: { $numberInt: '0' },
+                roundId: 1,
+                courseId: '014',
+                courseName: 'Augusta National Golf Club',
+                strokes: { $numberInt: '72' },
+              },
+            ],
+            thru: '9',
+            startingHole: 1,
+            currentHole: 10,
+          },
+        ],
+      }),
+    }))
+
+    const scores = await getTournamentScores('014', 2026)
+
+    expect(scores).toHaveLength(1)
+    const golfer = scores[0]!
+    expect(golfer.total_score).toBe(0)
+    expect(golfer.current_round_score).toBe(0)
+    expect(golfer.rounds!).toHaveLength(1)
+    const round = golfer.rounds![0]!
+    expect(round.score_to_par).toBe(0)
+    expect(round.strokes).toBe(72)
+  })
 })

--- a/src/lib/__tests__/slash-golf-client.test.ts
+++ b/src/lib/__tests__/slash-golf-client.test.ts
@@ -44,4 +44,71 @@ describe('getTournamentScores', () => {
       },
     ])
   })
+
+  it('normalizes live leaderboard rows with round snapshots', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        orgId: '1',
+        year: '2026',
+        tournId: '014',
+        status: 'In Progress',
+        roundId: 2,
+        roundStatus: 'In Progress',
+        timestamp: '2026-04-10T15:23:33.217000',
+        leaderboardRows: [
+          {
+            lastName: 'Rose',
+            firstName: 'Justin',
+            isAmateur: false,
+            playerId: '22405',
+            teeTime: '9:55am',
+            teeTimeTimestamp: '2026-04-10T13:55:00',
+            courseId: '014',
+            status: 'active',
+            currentRound: 2,
+            total: '-1',
+            currentRoundScore: '+1',
+            position: 'T11',
+            totalStrokesFromCompletedRounds: '70',
+            roundComplete: false,
+            rounds: [
+              {
+                scoreToPar: '-2',
+                roundId: 1,
+                courseId: '014',
+                courseName: 'Augusta National Golf Club',
+                strokes: 70,
+              },
+            ],
+            thru: '4',
+            startingHole: 1,
+            currentHole: 5,
+          },
+        ],
+      }),
+    }))
+
+    const scores = await getTournamentScores('014', 2026)
+
+    expect(scores).toHaveLength(1)
+    expect(scores[0]).toMatchObject({
+      golfer_id: '22405',
+      current_round: 2,
+      current_round_score: 1,
+      total_score: -1,
+      position: 'T11',
+      current_hole: 5,
+      thru: 4,
+      rounds: [
+        {
+          round_id: 1,
+          strokes: 70,
+          score_to_par: -2,
+          course_id: '014',
+          course_name: 'Augusta National Golf Club',
+        },
+      ],
+    })
+  })
 })

--- a/src/lib/slash-golf/client.ts
+++ b/src/lib/slash-golf/client.ts
@@ -129,10 +129,12 @@ function parseScoreValue(value: unknown): number | null {
     return Number.isFinite(parsed) ? parsed : null
   }
   if (typeof value === 'object' && value !== null && '$numberInt' in value) {
-    return parseInt((value as { '$numberInt': string })['$numberInt'], 10) || null
+    const parsed = parseInt((value as { '$numberInt': string })['$numberInt'], 10)
+    return Number.isFinite(parsed) ? parsed : null
   }
   if (typeof value === 'object' && value !== null && '$numberDouble' in value) {
-    return parseFloat((value as { '$numberDouble': string })['$numberDouble']) || null
+    const parsed = parseFloat((value as { '$numberDouble': string })['$numberDouble'])
+    return Number.isFinite(parsed) ? parsed : null
   }
   return null
 }
@@ -144,10 +146,12 @@ function parseMongoNumber(value: unknown): number | null {
     return Number.isFinite(parsed) ? parsed : null
   }
   if (typeof value === 'object' && value !== null && '$numberInt' in value) {
-    return parseInt((value as { '$numberInt': string })['$numberInt'], 10) || null
+    const parsed = parseInt((value as { '$numberInt': string })['$numberInt'], 10)
+    return Number.isFinite(parsed) ? parsed : null
   }
   if (typeof value === 'object' && value !== null && '$numberDouble' in value) {
-    return parseFloat((value as { '$numberDouble': string })['$numberDouble']) || null
+    const parsed = parseFloat((value as { '$numberDouble': string })['$numberDouble'])
+    return Number.isFinite(parsed) ? parsed : null
   }
   return null
 }

--- a/src/lib/slash-golf/client.ts
+++ b/src/lib/slash-golf/client.ts
@@ -67,13 +67,13 @@ function normalizeTournamentScores(raw: unknown): GolferScore[] | null {
       null
 
     if (!golferId) return []
-
+    
     // Round-based leaderboard shape.
     if ('leaderboardRows' in (raw as Record<string, unknown>) || 'rounds' in scoreRecord || 'currentRoundScore' in scoreRecord) {
       const rounds = Array.isArray(scoreRecord.rounds) ? scoreRecord.rounds : []
 
       const parsedRounds: GolferScoreRound[] = rounds.map((r: Record<string, unknown>) => ({
-        round_id: typeof r.roundId === 'number' ? r.roundId : 0,
+        round_id: parseMongoNumber(r.roundId) ?? 0,
         strokes: parseScoreValue(r.strokes),
         score_to_par: parseScoreValue(r.scoreToPar),
         course_id: typeof r.courseId === 'string' ? r.courseId : null,
@@ -96,8 +96,8 @@ function normalizeTournamentScores(raw: unknown): GolferScore[] | null {
         position: typeof scoreRecord.position === 'string' ? scoreRecord.position : null,
         current_hole: parseHoleValue(scoreRecord.currentHole),
         thru: parseThruValue(scoreRecord.thru),
-        starting_hole: typeof scoreRecord.startingHole === 'number' ? scoreRecord.startingHole : null,
-        current_round: typeof scoreRecord.currentRound === 'number' ? scoreRecord.currentRound : null,
+        starting_hole: parseMongoNumber(scoreRecord.startingHole),
+        current_round: parseMongoNumber(scoreRecord.currentRound),
         current_round_score: parseScoreValue(scoreRecord.currentRoundScore),
         tee_time: typeof scoreRecord.teeTime === 'string' ? scoreRecord.teeTime : null,
         tee_time_timestamp: typeof scoreRecord.teeTimeTimestamp === 'string' ? scoreRecord.teeTimeTimestamp : null,
@@ -122,21 +122,43 @@ function normalizeTournamentScores(raw: unknown): GolferScore[] | null {
 
 function parseScoreValue(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) return value
-  if (typeof value !== 'string') return null
+  if (typeof value === 'string') {
+    const normalized = value.trim()
+    if (!normalized || normalized === '-') return null
+    const parsed = Number(normalized.replace(/\*$/, ''))
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  if (typeof value === 'object' && value !== null && '$numberInt' in value) {
+    return parseInt((value as { '$numberInt': string })['$numberInt'], 10) || null
+  }
+  if (typeof value === 'object' && value !== null && '$numberDouble' in value) {
+    return parseFloat((value as { '$numberDouble': string })['$numberDouble']) || null
+  }
+  return null
+}
 
-  const normalized = value.trim()
-  if (!normalized || normalized === '-') return null
-
-  const parsed = Number(normalized.replace(/\*$/, ''))
-  return Number.isFinite(parsed) ? parsed : null
+function parseMongoNumber(value: unknown): number | null {
+  if (typeof value === 'number') return value
+  if (typeof value === 'string') {
+    const parsed = parseFloat(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  if (typeof value === 'object' && value !== null && '$numberInt' in value) {
+    return parseInt((value as { '$numberInt': string })['$numberInt'], 10) || null
+  }
+  if (typeof value === 'object' && value !== null && '$numberDouble' in value) {
+    return parseFloat((value as { '$numberDouble': string })['$numberDouble']) || null
+  }
+  return null
 }
 
 function parseHoleValue(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) return value
-  if (typeof value !== 'string') return null
-
-  const parsed = Number(value.replace(/\*$/, ''))
-  return Number.isFinite(parsed) ? parsed : null
+  if (typeof value === 'string') {
+    const parsed = Number(value.replace(/\*$/, ''))
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return parseMongoNumber(value)
 }
 
 function normalizeGolferStatus(value: unknown): 'active' | 'withdrawn' | 'cut' {

--- a/supabase/migrations/20260410103000_grant_service_role_tournament_score_rounds.sql
+++ b/supabase/migrations/20260410103000_grant_service_role_tournament_score_rounds.sql
@@ -1,0 +1,1 @@
+grant select, insert, update, delete on table public.tournament_score_rounds to service_role;


### PR DESCRIPTION
## Summary
- Fix pool.test.ts: change deadline from `2026-04-10` to `2026-04-11` so the test date stays reliably in the future
- Fix pool-delete-actions.test.ts: update expected error message to match current implementation

## Changes
- `src/lib/__tests__/pool.test.ts`: deadline date updated
- `src/app/(app)/commissioner/pools/[poolId]/__tests__/pool-delete-actions.test.ts`: error message updated