### PR TITLE
Epic 7.2: Build theme-aware UI primitive components

### DIFF
--- a/docs/qa/OPS-22-qa-report.md
+++ b/docs/qa/OPS-22-qa-report.md
@@ -1,0 +1,79 @@
+# QA Report — OPS-22: Epic 7.2 Build theme-aware UI primitive components
+
+**Story:** [OPS-22](/OPS/issues/OPS-22)
+**Reviewer:** Review/QA Gate
+**Date:** 2026-04-18
+**PR:** https://github.com/opsclawd/fantasy-golf/pull/10
+**Branch:** `feature/OPS-22-theme-aware-ui-primitives`
+**Rework round:** 2 (previous review had 2 MUST_FIX items)
+
+---
+
+## Stage 1: Spec Compliance Review
+
+| # | Acceptance Criterion | Result | Evidence |
+|---|---|---|---|
+| AC-1 | Button `variant="primary"` (green fill) and `variant="secondary"` (sand outline) | **PASS** | `Button.tsx`: primary=`bg-green-700 text-white hover:bg-green-900`, secondary=`bg-white text-stone-700 border border-stone-300`. 14 tests in `Button.test.tsx` verify all variant/size/attribute classes. |
+| AC-2 | Card `accent="left"` prop for green left border | **PASS** | `Card.tsx` exists. `accent="left"` produces `border-l-4 border-l-green-700`. `accent="none"` and undefined produce no accent classes. 7 tests in `Card.test.tsx`. |
+| AC-3 | StatusChip uses green/sand with icon+color pattern (never color alone) | **PASS** | `open`→green tokens, `complete`/`archived`→stone tokens, `live`→sky retained. `aria-label` + `aria-hidden` on icon preserved. Token regression tests verify no emerald/slate. |
+| AC-4 | LockBanner green-100 for open, stone-100 for locked | **PASS** | Locked: `bg-stone-100/90`, `border-stone-200`. Open: `bg-green-100/90`, `border-green-200`. `role="status"` and `aria-live="polite"` preserved. Token regression tests verify both states. |
+| AC-5 | TrustStatusBar green/sand treatment for freshness | **PASS** | Info tone: `border-green-200/80 bg-white/95 text-stone-900`. Labels: `text-stone-950`, `text-stone-600`, `text-stone-800`. Token regression tests verify no emerald/slate. |
+| AC-6 | WCAG 2.1 AA contrast audit | **PASS** | All ratios documented in spec §5.1 pass AA. `stone-600` used instead of `stone-500` for small label text (5.6:1 vs 4.0:1). |
+| AC-7 | Touch targets >= 44px | **PASS** | `globals.css` enforces `min-block-size: 44px` globally. Button inherits this. No explicit min-h needed. |
+
+### Previous MUST_FIX items — resolved
+
+1. ~~Card.tsx missing~~ → Card.tsx now exists with `accent="left"` and `accent="none"` support. **RESOLVED.**
+2. ~~`uiStyles.ts` `scrollRegionFocusClasses` used `ring-green-600` instead of spec-required `ring-green-500`~~ → Now uses `focus-visible:ring-green-500`. **RESOLVED.**
+
+### Unauthorized additions
+
+None found. All changes trace to plan tasks.
+
+---
+
+## Stage 2: Code Quality Review
+
+- **Test coverage:** Button (14 tests), Card (7 tests), StatusChip token regression (3 tests), LockBanner token regression (2 tests), TrustStatusBar token regression (2 tests) = 28 new tests. Existing behavioral tests continue passing. Total: 290 tests.
+- **Error handling:** Components handle edge cases (disabled state on Button, undefined accent on Card).
+- **TDD adherence:** Plan specifies TDD-first for Button and Card. Commit history shows implementation and tests created together per plan task structure.
+- **DRY:** No copy-paste duplication. Button and Card use clean class maps. StatusChip/LockBanner/TrustStatusBar share `uiStyles.ts` utilities.
+- **Naming:** Consistent with codebase conventions. Components use `createElement` pattern matching existing TrustStatusBar style.
+- **Security:** No secrets, no SQL injection, no XSS. Components use `createElement` which escapes by default.
+- **Accessibility:** All status components retain `role="status"`, `aria-live`, `aria-label`. Icon elements are `aria-hidden`. Button has `focus-visible:ring-2` for keyboard users. Card accent is decorative (no ARIA needed).
+- `[SUGGESTION]` `pageShellClasses()` still uses `text-slate-900` (line 5 uiStyles.ts). Per spec §4.6, this is explicitly out of scope for this story. Noted for future migration.
+
+---
+
+## Stage 3: Application-Level QA
+
+### Test suite results
+
+| Suite | Result |
+|---|---|
+| `npm test` (Vitest) | 290/290 PASS |
+| `npm run build` (Next.js) | Success — compiled, type-checked, static pages generated |
+| `npm run lint` (ESLint) | No warnings or errors |
+
+### Emerald/slate audit
+
+```
+grep 'emerald-' in modified files → No matches
+grep 'slate-' in modified files → 1 match: pageShellClasses() text-slate-900 (out of scope per spec §4.6)
+```
+
+### Playwright
+
+Not applicable — these are UI primitive components (Button, Card, token migrations) verified through unit tests. No user-facing pages were modified. Component rendering is verified through `renderToStaticMarkup` assertions that confirm exact class tokens.
+
+---
+
+## Verdict
+
+**QA PASSED.** All acceptance criteria verified. All 290 tests passing. Build and lint clean. Both MUST_FIX items from previous review resolved. No new MUST_FIX items found.
+
+- AC items: 7/7 PASS
+- Test suite: 290/290 PASS
+- Build: PASS
+- Lint: PASS
+- Emerald/slate audit: PASS (only out-of-scope `pageShellClasses` reference retained)

--- a/src/components/LockBanner.tsx
+++ b/src/components/LockBanner.tsx
@@ -45,20 +45,20 @@ export function LockBanner({ isLocked, deadline, poolStatus, timezone }: LockBan
   if (isLocked) {
     return (
       <div
-        className={`${panelClasses()} mb-4 flex items-center gap-3 border border-slate-200 bg-slate-100/90 p-4`}
+        className={`${panelClasses()} mb-4 flex items-center gap-3 border border-stone-200 bg-stone-100/90 p-4`}
         role="status"
         aria-live="polite"
       >
         <span
           aria-hidden="true"
-          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-slate-300 bg-white/75 text-lg"
+          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-stone-300 bg-white/75 text-lg"
         >
           &#x1F512;
         </span>
         <div>
           <p className={sectionHeadingClasses()}>Tournament lock</p>
-          <p className="text-base font-semibold text-slate-950">Picks are locked</p>
-          <p className="text-sm text-slate-700">{lockedMessage}</p>
+          <p className="text-base font-semibold text-stone-950">Picks are locked</p>
+          <p className="text-sm text-stone-700">{lockedMessage}</p>
         </div>
       </div>
     )
@@ -68,20 +68,20 @@ export function LockBanner({ isLocked, deadline, poolStatus, timezone }: LockBan
 
   return (
     <div
-      className={`${panelClasses()} mb-4 flex items-center gap-3 border border-emerald-200 bg-emerald-50/90 p-4`}
+      className={`${panelClasses()} mb-4 flex items-center gap-3 border border-green-200 bg-green-100/90 p-4`}
       role="status"
       aria-live="polite"
     >
       <span
         aria-hidden="true"
-        className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-emerald-200 bg-white/75 text-lg"
+          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-green-200 bg-white/75 text-lg"
       >
         &#x1F513;
       </span>
       <div>
-        <p className={`${sectionHeadingClasses()} text-emerald-800`}>Tournament lock</p>
-        <p className="text-base font-semibold text-emerald-950">Picks are open</p>
-        <p className="text-sm text-emerald-900">
+        <p className={`${sectionHeadingClasses()} text-green-900`}>Tournament lock</p>
+        <p className="text-base font-semibold text-green-950">Picks are open</p>
+        <p className="text-sm text-green-800">
           Deadline: {formattedDeadline}
         </p>
       </div>

--- a/src/components/StatusChip.tsx
+++ b/src/components/StatusChip.tsx
@@ -6,7 +6,7 @@ const STATUS_CONFIG: Record<PoolStatus, { label: string; icon: string; classes: 
   open: {
     label: 'Open',
     icon: '\u25CB', // circle outline
-    classes: 'border-emerald-200 bg-emerald-50 text-emerald-900',
+    classes: 'border-green-200 bg-green-50 text-green-900',
   },
   live: {
     label: 'Live',
@@ -16,12 +16,12 @@ const STATUS_CONFIG: Record<PoolStatus, { label: string; icon: string; classes: 
   complete: {
     label: 'Complete',
     icon: '\u2713', // checkmark
-    classes: 'border-slate-200 bg-slate-100 text-slate-900',
+    classes: 'border-stone-200 bg-stone-100 text-stone-900',
   },
   archived: {
     label: 'Archived',
     icon: '\u25A3', // filled square
-    classes: 'border-slate-200 bg-slate-100 text-slate-700',
+    classes: 'border-stone-200 bg-stone-100 text-stone-700',
   },
 }
 
@@ -34,7 +34,7 @@ export function StatusChip({ status }: { status: PoolStatus }) {
       aria-label={`Pool status: ${config.label}`}
     >
       <span aria-hidden="true">{config.icon}</span>
-      <span className={sectionHeadingClasses().replace('text-emerald-800/70', 'text-current')}>
+      <span className={sectionHeadingClasses().replace('text-green-800/70', 'text-current')}>
         {config.label}
       </span>
     </span>

--- a/src/components/TrustStatusBar.tsx
+++ b/src/components/TrustStatusBar.tsx
@@ -108,7 +108,7 @@ function toneClasses(tone: TrustTone): string {
     case 'warning':
       return 'border-amber-200/80 bg-amber-50/95 text-amber-950'
     default:
-      return 'border-emerald-200/80 bg-white/95 text-slate-900'
+      return 'border-green-200/80 bg-white/95 text-stone-900'
   }
 }
 
@@ -186,7 +186,7 @@ export function TrustStatusBar({ className, ...input }: TrustStatusBarProps) {
         createElement('p', { className: sectionHeadingClasses() }, state.heading),
         createElement(
           'p',
-          { className: 'flex items-center gap-2 text-base font-semibold text-slate-950' },
+          { className: 'flex items-center gap-2 text-base font-semibold text-stone-950' },
           createElement('span', { 'aria-hidden': 'true' }, state.icon),
           createElement('span', null, `${state.lockLabel} for this pool`),
         ),
@@ -200,17 +200,17 @@ export function TrustStatusBar({ className, ...input }: TrustStatusBarProps) {
         state.lockLabel,
       ),
     ),
-    createElement('p', { className: 'mt-3 text-sm text-slate-800' }, state.lockMessage),
+    createElement('p', { className: 'mt-3 text-sm text-stone-800' }, state.lockMessage),
     state.showFreshness
       ? createElement(
           'div',
           { className: 'mt-3 rounded-2xl border border-black/5 bg-white/65 px-3 py-2' },
           createElement(
             'p',
-            { className: 'text-xs font-semibold uppercase tracking-[0.18em] text-slate-500' },
+            { className: 'text-xs font-semibold uppercase tracking-[0.18em] text-stone-600' },
             `Freshness: ${state.freshnessLabel}`,
           ),
-          createElement('p', { className: 'mt-1 text-sm text-slate-800' }, state.freshnessMessage),
+          createElement('p', { className: 'mt-1 text-sm text-stone-800' }, state.freshnessMessage),
         )
       : null,
   )

--- a/src/components/__tests__/LockBanner.test.tsx
+++ b/src/components/__tests__/LockBanner.test.tsx
@@ -37,3 +37,36 @@ describe('LockBanner', () => {
     expect(markup).toContain('This pool is archived. Picks are read-only.')
   })
 })
+
+describe('LockBanner token migration', () => {
+  it('uses stone tokens for locked state (not slate)', () => {
+    const props: any = {
+      isLocked: true,
+      deadline: '2026-04-09T00:00:00+00:00',
+      poolStatus: 'complete',
+      timezone: 'America/New_York',
+    }
+    const markup = renderToStaticMarkup(<LockBanner {...props} />)
+
+    expect(markup).toContain('border-stone-200')
+    expect(markup).toContain('bg-stone-100')
+    expect(markup).not.toContain('slate-')
+    expect(markup).not.toContain('emerald-')
+  })
+
+  it('uses green tokens for open state (not emerald)', () => {
+    const props: any = {
+      isLocked: false,
+      deadline: '2026-04-09T00:00:00+00:00',
+      poolStatus: 'open',
+      timezone: 'America/New_York',
+    }
+    const markup = renderToStaticMarkup(<LockBanner {...props} />)
+
+    expect(markup).toContain('border-green-200')
+    expect(markup).toContain('bg-green-100')
+    expect(markup).toContain('text-green-950')
+    expect(markup).not.toContain('emerald-')
+    expect(markup).not.toContain('slate-')
+  })
+})

--- a/src/components/__tests__/StatusComponentsA11y.test.tsx
+++ b/src/components/__tests__/StatusComponentsA11y.test.tsx
@@ -62,3 +62,39 @@ describe('status component accessibility attributes', () => {
     expect(markup).toContain('aria-valuemax="4"')
   })
 })
+
+describe('StatusChip token migration', () => {
+  it('uses green tokens for open status (not emerald)', () => {
+    const markup = renderToStaticMarkup(
+      createElement(StatusChip, { status: 'open' }),
+    )
+    expect(markup).toContain('border-green-200')
+    expect(markup).toContain('bg-green-50')
+    expect(markup).toContain('text-green-900')
+    expect(markup).not.toContain('emerald-')
+  })
+
+  it('uses stone tokens for complete and archived status (not slate)', () => {
+    const markup = renderToStaticMarkup(
+      createElement(StatusChip, { status: 'complete' }),
+    )
+    expect(markup).toContain('border-stone-200')
+    expect(markup).toContain('bg-stone-100')
+    expect(markup).not.toContain('slate-')
+
+    const archivedMarkup = renderToStaticMarkup(
+      createElement(StatusChip, { status: 'archived' }),
+    )
+    expect(archivedMarkup).toContain('border-stone-200')
+    expect(archivedMarkup).not.toContain('slate-')
+  })
+
+  it('retains sky tokens for live status', () => {
+    const markup = renderToStaticMarkup(
+      createElement(StatusChip, { status: 'live' }),
+    )
+    expect(markup).toContain('border-sky-200')
+    expect(markup).toContain('bg-sky-50')
+    expect(markup).toContain('text-sky-900')
+  })
+})

--- a/src/components/__tests__/TrustStatusBar.test.tsx
+++ b/src/components/__tests__/TrustStatusBar.test.tsx
@@ -220,3 +220,37 @@ describe('getTrustStatusBarState', () => {
     expect(result.freshnessMessage).toContain('Refreshing scores...')
   })
 })
+
+describe('TrustStatusBar token migration', () => {
+  it('uses green/stone tokens for info tone (not emerald/slate)', () => {
+    const markup = renderToStaticMarkup(
+      createElement(TrustStatusBar, {
+        isLocked: false,
+        poolStatus: 'open',
+        freshness: 'current',
+        refreshedAt: '2026-03-29T12:00:00.000Z',
+        lastRefreshError: null,
+      }),
+    )
+
+    expect(markup).toContain('border-green-200')
+    expect(markup).toContain('text-stone-900')
+    expect(markup).not.toContain('emerald-')
+    expect(markup).not.toContain('slate-')
+  })
+
+  it('uses stone-600 for freshness labels (not slate-500)', () => {
+    const markup = renderToStaticMarkup(
+      createElement(TrustStatusBar, {
+        isLocked: true,
+        poolStatus: 'live',
+        freshness: 'current',
+        refreshedAt: '2026-03-29T12:00:00.000Z',
+        lastRefreshError: null,
+      }),
+    )
+
+    expect(markup).toContain('text-stone-600')
+    expect(markup).not.toContain('text-slate-500')
+  })
+})

--- a/src/components/__tests__/uiStyles.test.ts
+++ b/src/components/__tests__/uiStyles.test.ts
@@ -29,7 +29,7 @@ describe('uiStyles', () => {
   it('returns visible focus classes for keyboard-scroll regions', () => {
     expect(scrollRegionFocusClasses()).toContain('focus-visible:ring-inset')
     expect(scrollRegionFocusClasses()).toContain('focus-visible:ring-2')
-    expect(scrollRegionFocusClasses()).toContain('focus-visible:ring-emerald-500')
+    expect(scrollRegionFocusClasses()).toContain('focus-visible:ring-green-500')
     expect(scrollRegionFocusClasses()).not.toContain('focus-visible:ring-offset-2')
     expect(scrollRegionFocusClasses()).not.toBe('focus-visible:outline-none')
   })

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,43 @@
+import { type ButtonHTMLAttributes, createElement } from 'react'
+
+type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost'
+type ButtonSize = 'sm' | 'md' | 'lg'
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: 'bg-green-700 text-white hover:bg-green-900 focus-visible:ring-green-500',
+  secondary: 'bg-white text-stone-700 border border-stone-300 hover:bg-stone-50 focus-visible:ring-green-500',
+  danger: 'bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-500',
+  ghost: 'bg-transparent text-stone-600 hover:bg-stone-50 focus-visible:ring-green-500',
+}
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2.5 text-base',
+  lg: 'px-6 py-3 text-base font-semibold',
+}
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+}
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  className = '',
+  children,
+  ...rest
+}: ButtonProps) {
+  const classes = [
+    'inline-flex items-center justify-center rounded-lg',
+    variantClasses[variant],
+    sizeClasses[size],
+    'focus-visible:ring-2 focus-visible:ring-offset-2',
+    'disabled:opacity-50 disabled:cursor-not-allowed',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return createElement('button', { className: classes, ...rest }, children)
+}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,26 @@
+import { type HTMLAttributes, createElement } from 'react'
+
+import { panelClasses } from '../uiStyles'
+
+type CardAccent = 'left' | 'none'
+
+const accentClasses: Record<CardAccent, string> = {
+  left: 'border-l-4 border-l-green-700',
+  none: '',
+}
+
+interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  accent?: CardAccent
+}
+
+export function Card({ accent, className = '', children, ...rest }: CardProps) {
+  const classes = [
+    panelClasses(),
+    accent ? accentClasses[accent] : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return createElement('div', { className: classes, ...rest }, children)
+}

--- a/src/components/ui/__tests__/Button.test.tsx
+++ b/src/components/ui/__tests__/Button.test.tsx
@@ -1,0 +1,99 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { createElement } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { Button } from '../Button'
+
+describe('Button', () => {
+  it('renders a button element', () => {
+    const markup = renderToStaticMarkup(createElement(Button, null, 'Click me'))
+    expect(markup).toContain('Click me')
+    expect(markup).toMatch(/^<button/)
+  })
+
+  it('applies primary variant classes by default', () => {
+    const markup = renderToStaticMarkup(createElement(Button, null, 'Go'))
+    expect(markup).toContain('bg-green-700')
+    expect(markup).toContain('text-white')
+    expect(markup).toContain('focus-visible:ring-green-500')
+  })
+
+  it('applies secondary variant classes', () => {
+    const markup = renderToStaticMarkup(createElement(Button, { variant: 'secondary' }, 'Cancel'))
+    expect(markup).toContain('bg-white')
+    expect(markup).toContain('text-stone-700')
+    expect(markup).toContain('border-stone-300')
+    expect(markup).toContain('focus-visible:ring-green-500')
+  })
+
+  it('applies danger variant classes', () => {
+    const markup = renderToStaticMarkup(createElement(Button, { variant: 'danger' }, 'Delete'))
+    expect(markup).toContain('bg-red-600')
+    expect(markup).toContain('text-white')
+    expect(markup).toContain('focus-visible:ring-red-500')
+  })
+
+  it('applies ghost variant classes', () => {
+    const markup = renderToStaticMarkup(createElement(Button, { variant: 'ghost' }, 'Skip'))
+    expect(markup).toContain('bg-transparent')
+    expect(markup).toContain('text-stone-600')
+    expect(markup).toContain('focus-visible:ring-green-500')
+  })
+
+  it('applies md size classes by default', () => {
+    const markup = renderToStaticMarkup(createElement(Button, null, 'Medium'))
+    expect(markup).toContain('px-4')
+    expect(markup).toContain('py-2.5')
+  })
+
+  it('applies sm size classes', () => {
+    const markup = renderToStaticMarkup(createElement(Button, { size: 'sm' }, 'Small'))
+    expect(markup).toContain('px-3')
+    expect(markup).toContain('py-1.5')
+  })
+
+  it('applies lg size classes', () => {
+    const markup = renderToStaticMarkup(createElement(Button, { size: 'lg' }, 'Large'))
+    expect(markup).toContain('px-6')
+    expect(markup).toContain('py-3')
+  })
+
+  it('passes through HTML button attributes', () => {
+    const markup = renderToStaticMarkup(
+      createElement(Button, { type: 'submit', disabled: true, 'aria-label': 'Submit form' }, 'Submit'),
+    )
+    expect(markup).toContain('type="submit"')
+    expect(markup).toContain('disabled')
+    expect(markup).toContain('aria-label="Submit form"')
+    expect(markup).toContain('disabled:opacity-50')
+  })
+
+  it('applies focus-visible ring classes', () => {
+    const markup = renderToStaticMarkup(createElement(Button, null, 'Focus'))
+    expect(markup).toContain('focus-visible:ring-2')
+    expect(markup).toContain('focus-visible:ring-offset-2')
+  })
+
+  it('applies hover state classes for primary variant', () => {
+    const markup = renderToStaticMarkup(createElement(Button, { variant: 'primary' }, 'Hover'))
+    expect(markup).toContain('hover:bg-green-900')
+  })
+
+  it('applies hover state classes for secondary variant', () => {
+    const markup = renderToStaticMarkup(createElement(Button, { variant: 'secondary' }, 'Hover'))
+    expect(markup).toContain('hover:bg-stone-50')
+  })
+
+  it('applies rounded class for consistent shape', () => {
+    const markup = renderToStaticMarkup(createElement(Button, null, 'Rounded'))
+    expect(markup).toContain('rounded-lg')
+  })
+
+  it('merges additional className prop', () => {
+    const markup = renderToStaticMarkup(
+      createElement(Button, { className: 'mt-4' }, 'Extra'),
+    )
+    expect(markup).toContain('mt-4')
+    expect(markup).toContain('bg-green-700')
+  })
+})

--- a/src/components/ui/__tests__/Card.test.tsx
+++ b/src/components/ui/__tests__/Card.test.tsx
@@ -1,0 +1,56 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { createElement } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { Card } from '../Card'
+
+describe('Card', () => {
+  it('renders children inside a div', () => {
+    const markup = renderToStaticMarkup(createElement(Card, null, 'Hello world'))
+    expect(markup).toContain('Hello world')
+    expect(markup).toMatch(/^<div/)
+  })
+
+  it('applies panelClasses base styles by default', () => {
+    const markup = renderToStaticMarkup(createElement(Card, null, 'Content'))
+    expect(markup).toContain('rounded-3xl')
+    expect(markup).toContain('border-white/60')
+    expect(markup).toContain('bg-white/90')
+    expect(markup).toContain('backdrop-blur')
+  })
+
+  it('applies accent left border when accent="left"', () => {
+    const markup = renderToStaticMarkup(createElement(Card, { accent: 'left' }, 'Card content'))
+    expect(markup).toContain('border-l-4')
+    expect(markup).toContain('border-l-green-700')
+  })
+
+  it('does not apply accent classes when accent is undefined', () => {
+    const markup = renderToStaticMarkup(createElement(Card, null, 'No accent'))
+    expect(markup).not.toContain('border-l-4')
+    expect(markup).not.toContain('border-l-green-700')
+  })
+
+  it('does not apply accent classes when accent="none"', () => {
+    const markup = renderToStaticMarkup(createElement(Card, { accent: 'none' }, 'No accent'))
+    expect(markup).not.toContain('border-l-4')
+    expect(markup).not.toContain('border-l-green-700')
+  })
+
+  it('merges additional className prop', () => {
+    const markup = renderToStaticMarkup(
+      createElement(Card, { className: 'mt-4 p-6' }, 'Extra classes'),
+    )
+    expect(markup).toContain('mt-4')
+    expect(markup).toContain('p-6')
+    expect(markup).toContain('rounded-3xl')
+  })
+
+  it('passes through HTML div attributes', () => {
+    const markup = renderToStaticMarkup(
+      createElement(Card, { id: 'test-card', 'aria-label': 'Test card' }, 'Attrs'),
+    )
+    expect(markup).toContain('id="test-card"')
+    expect(markup).toContain('aria-label="Test card"')
+  })
+})

--- a/src/components/uiStyles.ts
+++ b/src/components/uiStyles.ts
@@ -26,7 +26,7 @@ export function scrollRegionFocusClasses() {
     'focus-visible:outline-none',
     'focus-visible:ring-inset',
     'focus-visible:ring-2',
-    'focus-visible:ring-emerald-500',
+    'focus-visible:ring-green-500',
   ].join(' ')
 }
 
@@ -36,6 +36,6 @@ export function sectionHeadingClasses() {
     'font-semibold',
     'uppercase',
     'tracking-[0.18em]',
-    'text-emerald-800/70',
+    'text-green-800/70',
   ].join(' ')
 }


### PR DESCRIPTION
## Summary

Implemented theme-aware UI primitive components for the fantasy-golf redesign:

- **Button component**: Primary/secondary/danger/ghost variants with sm/md/lg sizes
- **Card component**: With optional `accent=\"left\"` prop for green left border
- **StatusChip migration**: Emerald/slate → green/stone tokens
- **LockBanner migration**: Emerald/slate → green/stone tokens  
- **TrustStatusBar migration**: Emerald/slate → green/stone tokens
- **uiStyles updates**: sectionHeadingClasses and scrollRegionFocusClasses

All components use the new design token system from OPS-20.

## Testing

- 290 tests passing
- Token regression tests added for all migrated components
- Build succeeds with no TypeScript errors
- Lint passes

## Links

- Story: [OPS-22](/PAP/issues/OPS-22)
- Design Spec: [docs/superpowers/specs/2026-04-17-theme-aware-ui-primitives-design.md](/PAP/issues/OPS-22#document-design)
- Implementation Plan: [docs/superpowers/plans/2026-04-17-theme-aware-ui-primitives.md](/PAP/issues/OPS-22#document-plan)

## How to Verify

1. Run `npm run test` - all 290 tests should pass
2. Run `npm run build` - should succeed
3. Check Button component renders correctly with all variants
4. Check Card component with `accent=\"left\"` shows green border
5. Check StatusChip, LockBanner, TrustStatusBar use green/stone colors