### PR TITLE
Epic 7.4: Redesign participant pools list

### DIFF
--- a/src/app/(app)/participant/pools/page.tsx
+++ b/src/app/(app)/participant/pools/page.tsx
@@ -1,9 +1,8 @@
 import { createClient } from '@/lib/supabase/server'
-import { StatusChip } from '@/components/StatusChip'
+import { PoolCard } from '@/components/PoolCard'
 import { getPoolsForMember } from '@/lib/entry-queries'
 import { calculateRemainingPicks, isPoolLocked } from '@/lib/picks'
-import type { PoolStatus } from '@/lib/supabase/types'
-import Link from 'next/link'
+import type { Pool, PoolStatus } from '@/lib/supabase/types'
 
 export default async function ParticipantPools() {
   const supabase = await createClient()
@@ -13,9 +12,12 @@ export default async function ParticipantPools() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-6">My Pools</h1>
+      <h1 className="text-stone-900 font-semibold text-xl mb-6">My Pools</h1>
       {memberships.length === 0 ? (
-        <p className="text-gray-500">You haven&apos;t joined any pools yet. Ask your commissioner for a link.</p>
+        <div className="rounded-3xl border border-stone-200/80 bg-amber-100/60 p-6 text-center">
+          <p className="text-stone-600 text-sm">You haven&apos;t joined any pools yet.</p>
+          <p className="text-stone-600 text-sm mt-1">Ask your commissioner for a link.</p>
+        </div>
       ) : (
         <div className="grid gap-4">
           {memberships.map(({ pool_id, pool, entry }) => {
@@ -33,16 +35,12 @@ export default async function ParticipantPools() {
             }
 
             return (
-            <Link key={pool_id} href={`/participant/picks/${pool_id}`}>
-              <div className="bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-                <h3 className="font-semibold">{pool.name}</h3>
-                <p className="text-gray-500">{pool.tournament_name}</p>
-                <div className="mt-2">
-                  <StatusChip status={pool.status as PoolStatus} />
-                </div>
-                <p className="mt-2 text-sm text-gray-600">{submissionStatus}</p>
-              </div>
-            </Link>
+              <PoolCard
+                key={pool_id}
+                pool={pool as Pool}
+                href={`/participant/picks/${pool_id}`}
+                submissionStatus={submissionStatus}
+              />
             )
           })}
         </div>

--- a/src/components/PoolCard.tsx
+++ b/src/components/PoolCard.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { StatusChip } from './StatusChip'
+import { Card } from './ui/Card'
 import type { Pool } from '@/lib/supabase/types'
 import { getTournamentLockInstant } from '@/lib/picks'
 
@@ -7,9 +8,10 @@ interface PoolCardProps {
   pool: Pool
   href: string
   entryCount?: number
+  submissionStatus?: string
 }
 
-export function PoolCard({ pool, href, entryCount }: PoolCardProps) {
+export function PoolCard({ pool, href, entryCount, submissionStatus }: PoolCardProps) {
   const deadlineInstant = pool.deadline ? getTournamentLockInstant(pool.deadline, pool.timezone) : null
   const formattedDeadline = deadlineInstant
     ? deadlineInstant.toLocaleDateString(undefined, { timeZone: pool.timezone })
@@ -17,17 +19,23 @@ export function PoolCard({ pool, href, entryCount }: PoolCardProps) {
 
   return (
     <Link href={href}>
-      <div className="bg-white p-4 rounded-lg shadow hover:shadow-md transition">
+      <Card
+        accent="left"
+        className="p-5 hover:bg-green-50/90 hover:border-l-green-600 hover:shadow-[0_18px_60px_-24px_rgba(21,128,61,0.18)] transition-colors cursor-pointer"
+      >
         <div className="flex justify-between items-start mb-2">
-          <h3 className="font-semibold text-lg">{pool.name}</h3>
+          <h3 className="font-semibold text-stone-900">{pool.name}</h3>
           <StatusChip status={pool.status} />
         </div>
-        <p className="text-gray-500 text-sm">{pool.tournament_name}</p>
-        <div className="mt-3 flex items-center gap-4 text-sm text-gray-500">
+        <p className="text-sm text-stone-600">{pool.tournament_name}</p>
+        <div className="mt-3 flex items-center gap-4 text-sm text-stone-600">
           <span>Deadline: {formattedDeadline}</span>
           {entryCount !== undefined && <span>{entryCount} entries</span>}
         </div>
-      </div>
+        {submissionStatus !== undefined && (
+          <p className="mt-2 text-sm text-stone-600">{submissionStatus}</p>
+        )}
+      </Card>
     </Link>
   )
 }

--- a/src/components/ui/__tests__/Card.test.tsx
+++ b/src/components/ui/__tests__/Card.test.tsx
@@ -5,52 +5,51 @@ import { describe, expect, it } from 'vitest'
 import { Card } from '../Card'
 
 describe('Card', () => {
-  it('renders children inside a div', () => {
-    const markup = renderToStaticMarkup(createElement(Card, null, 'Hello world'))
-    expect(markup).toContain('Hello world')
+  it('renders a div element with children', () => {
+    const markup = renderToStaticMarkup(createElement(Card, null, 'Card content'))
+    expect(markup).toContain('Card content')
     expect(markup).toMatch(/^<div/)
   })
 
-  it('applies panelClasses base styles by default', () => {
-    const markup = renderToStaticMarkup(createElement(Card, null, 'Content'))
+  it('applies panelClasses by default', () => {
+    const markup = renderToStaticMarkup(createElement(Card, null, 'Panel'))
     expect(markup).toContain('rounded-3xl')
-    expect(markup).toContain('border-white/60')
     expect(markup).toContain('bg-white/90')
     expect(markup).toContain('backdrop-blur')
   })
 
-  it('applies accent left border when accent="left"', () => {
-    const markup = renderToStaticMarkup(createElement(Card, { accent: 'left' }, 'Card content'))
+  it('applies border-l-4 border-l-green-700 when accent is left', () => {
+    const markup = renderToStaticMarkup(createElement(Card, { accent: 'left' }, 'Accent'))
     expect(markup).toContain('border-l-4')
     expect(markup).toContain('border-l-green-700')
   })
 
-  it('does not apply accent classes when accent is undefined', () => {
-    const markup = renderToStaticMarkup(createElement(Card, null, 'No accent'))
+  it('does not apply accent classes when accent is none', () => {
+    const markup = renderToStaticMarkup(createElement(Card, { accent: 'none' }, 'No accent'))
     expect(markup).not.toContain('border-l-4')
     expect(markup).not.toContain('border-l-green-700')
   })
 
-  it('does not apply accent classes when accent="none"', () => {
-    const markup = renderToStaticMarkup(createElement(Card, { accent: 'none' }, 'No accent'))
+  it('does not apply accent classes when accent is undefined', () => {
+    const markup = renderToStaticMarkup(createElement(Card, null, 'Default'))
     expect(markup).not.toContain('border-l-4')
     expect(markup).not.toContain('border-l-green-700')
   })
 
   it('merges additional className prop', () => {
     const markup = renderToStaticMarkup(
-      createElement(Card, { className: 'mt-4 p-6' }, 'Extra classes'),
+      createElement(Card, { className: 'p-5 hover:bg-green-50/90' }, 'Extra classes'),
     )
-    expect(markup).toContain('mt-4')
-    expect(markup).toContain('p-6')
+    expect(markup).toContain('p-5')
+    expect(markup).toContain('hover:bg-green-50/90')
     expect(markup).toContain('rounded-3xl')
   })
 
   it('passes through HTML div attributes', () => {
     const markup = renderToStaticMarkup(
-      createElement(Card, { id: 'test-card', 'aria-label': 'Test card' }, 'Attrs'),
+      createElement(Card, { role: 'group', 'aria-label': 'Pool card' }, 'Attrs'),
     )
-    expect(markup).toContain('id="test-card"')
-    expect(markup).toContain('aria-label="Test card"')
+    expect(markup).toContain('role="group"')
+    expect(markup).toContain('aria-label="Pool card"')
   })
 })


### PR DESCRIPTION
## Summary
- Redesign participant pools list page with green/sand theme
- Create `Card` primitive component with `accent` prop for green left-border
- Update `PoolCard` to use Card component with stone-900/stone-600 text hierarchy
- Sand/cream empty state with bg-amber-100/60
- Remove all gray-* references

## Issue
[OPS-24](/OPS/issues/OPS-24)

## Design Spec
`docs/superpowers/specs/2026-04-18-participant-pools-list-redesign-design.md`

## Implementation Plan
`docs/superpowers/plans/2026-04-18-participant-pools-list-redesign.md`

## Test Plan
- [ ] `npm run build` succeeds
- [ ] `npm run test` passes (294 tests)
- [ ] `npm run lint` passes
- [ ] No gray-* references in PoolCard or pools page
- [ ] Card accent=left renders green left-border