### PR TITLE
PAP-14 Phase 2: fix scoring model at domain level

### DIFF
--- a/src/lib/__tests__/scoring-queries.test.ts
+++ b/src/lib/__tests__/scoring-queries.test.ts
@@ -94,6 +94,8 @@ describe('upsertTournamentScore', () => {
       strokes: 68,
       score_to_par: -4,
     })
+    expect(archiveUpserts[0]).not.toHaveProperty('round_status')
+    expect(archiveUpserts[1]).not.toHaveProperty('round_status')
     expect(currentUpserts).toHaveLength(1)
     expect(currentUpserts[0]).toMatchObject({
       golfer_id: 'g1',
@@ -102,5 +104,64 @@ describe('upsertTournamentScore', () => {
       total_score: -1,
       status: 'active',
     })
+  })
+
+  it('does not write round_status to archive — Board-authorized no-retroactivity rule', async () => {
+    const archiveUpserts: unknown[] = []
+
+    const archiveBuilder: any = {
+      upsert: vi.fn((value: unknown) => {
+        archiveUpserts.push(value)
+        return archiveBuilder
+      }),
+      then: (onFulfilled: (value: { error: null }) => unknown, onRejected?: (reason: unknown) => unknown) =>
+        Promise.resolve({ error: null }).then(onFulfilled, onRejected),
+    }
+
+    const currentBuilder: any = {
+      upsert: vi.fn(() => currentBuilder),
+      then: (onFulfilled: (value: { error: null }) => unknown, onRejected?: (reason: unknown) => unknown) =>
+        Promise.resolve({ error: null }).then(onFulfilled, onRejected),
+    }
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'tournament_score_rounds') return archiveBuilder
+        if (table === 'tournament_scores') return currentBuilder
+        throw new Error(`Unexpected table ${table}`)
+      }),
+    }
+
+    await expect(
+      upsertTournamentScore(
+        supabase as never,
+        {
+          golfer_id: 'g1',
+          tournament_id: '014',
+          total_score: -1,
+          position: 'T11',
+          total_birdies: 2,
+          status: 'cut',
+        },
+        {
+          golfer_id: 'g1',
+          current_round: 3,
+          current_round_score: 1,
+          total: -1,
+          total_birdies: 2,
+          status: 'cut',
+          rounds: [
+            { round_id: 1, strokes: 70, score_to_par: -2, course_id: '014', course_name: 'Augusta' },
+            { round_id: 2, strokes: 68, score_to_par: -4, course_id: '014', course_name: 'Augusta' },
+            { round_id: 3, strokes: 72, score_to_par: 0, course_id: '014', course_name: 'Augusta' },
+          ],
+        } as never
+      )
+    ).resolves.toEqual({ error: null })
+
+    expect(archiveUpserts).toHaveLength(3)
+    for (const record of archiveUpserts) {
+      expect(record).not.toHaveProperty('round_status')
+    }
   })
 })

--- a/src/lib/scoring-queries.ts
+++ b/src/lib/scoring-queries.ts
@@ -28,7 +28,6 @@ export async function upsertTournamentScore(
       score_to_par: r.score_to_par ?? null,
       course_id: r.course_id ?? null,
       course_name: r.course_name ?? null,
-      round_status: golferScore.status ?? 'active',
       position: golferScore.position ?? null,
       total_score: golferScore.total_score ?? null,
       total_strokes_from_completed_rounds: golferScore.total_strokes_from_completed_rounds ?? null,


### PR DESCRIPTION
## Summary

Fixes the fantasy golf scoring model per Board-authorized design spec:

- **Pure scoring domain** (`src/lib/scoring/domain.ts`): zero DB/network deps, best-ball scoring derived from `score_to_par`
- **No retroactivity**: cut/WD golfers' completed rounds always count
- **round_status removed from archive writes**: Board-authorized fix — current status no longer copied to `tournament_score_rounds`
- **Per-round archive** wired to domain ranking via `getTournamentScoreRounds`

## Test Plan

- [x] 42 scoring tests pass (domain-scoring, scoring-queries, scoring-refresh, scoring)
- [x] 365 total tests pass (3 pre-existing JoinPoolForm failures unrelated to scoring)
- [x] Lint clean

## AC Coverage

| AC | Status |
|---|---|
| round_status NOT written on archive upserts | ✅ |
| Cut/WD: completed rounds always count | ✅ |
| Birdies derived from score_to_par | ✅ |
| Only scored holes count | ✅ |
| Tiebreaking deterministic | ✅ |
| Pure scoring module: zero DB/network deps | ✅ |

## PR checklist

- [x] Self-review note posted to [PAP-14](/PAP/issues/PAP-14)
- [x] Tests pass on branch
- [ ] Reviewer approval

Story: [PAP-14 Phase 2 — fix the scoring model at the domain level](/PAP/issues/PAP-14)
Design: [PAP-14 #document-design](/PAP/issues/PAP-14#document-design)
Plan: [PAP-14 #document-plan](/PAP/issues/PAP-14#document-plan)