### PR TITLE
OPS-52: Integrate Slash Golf scorecard-driven scoring flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,12 +66,37 @@ npx supabase db push  # Push migrations to remote DB
 
 ## Critical Rules
 
-- **Do not** couple scoring logic to Next.js handlers, React components, or Supabase SDK calls
-- **Do not** make client UI the source of truth for auth, deadlines, or scoring state
-- **Leaderboard freshness model**: the server owns staleness via a configurable threshold (currently 15m). The API triggers an upstream refresh on fetch when data is older than the threshold. The client re-fetches on: mount, realtime `scores` broadcasts, realtime channel reconnect (`SUBSCRIBED` after drop), and tab visibility change to `visible`. No fixed-interval polling. Always surface freshness/refreshing state in the UI so users can see when data is in-flight or stale.
-- Keep business rules in `src/lib/scoring.ts` and pure utilities; not in page components
-- Use server-side validation for all pool, pick, and scoring mutations
-- Preserve visible freshness and lock-state messaging in UI
+These are the non-negotiable rules for the MVP. The full authoritative specification is at [`docs/rules-spec.md`](./docs/rules-spec.md).
+
+### Game Rules
+
+- [ ] **Entry size**: Exactly `picks_per_entry` golfers (default: 4). No duplicates within an entry.
+- [ ] **Best-ball scoring**: Lowest `scoreToPar` among active golfers per round, summed across completed rounds.
+- [ ] **Tiebreaker**: Total score (lower is better) → total birdies (higher is better) → shared rank.
+- [ ] **Active golfers only**: `cut` and `withdrawn` golfers are excluded from best-ball calculation after they occur.
+- [ ] **Round completion gating**: A round only counts if ALL golfers in the entry have `isComplete: true`.
+- [ ] **Playoff holes**: Do NOT count toward MVP scoring.
+
+### Locking Rules
+
+- [ ] **Pick locks at pool deadline**: Lock instant = midnight (00:00) in the pool's configured timezone on the deadline date.
+- [ ] **Pool status lock**: Non-`open` pools are always locked regardless of deadline.
+- [ ] **All users subject to lock**: Commissioner picks lock the same as player picks.
+
+### Data Architecture
+
+- [ ] **Scoring logic is pure**: Keep in `src/lib/scoring.ts` and `src/lib/scoring/domain.ts`. No coupling to handlers, components, or Supabase SDK.
+- [ ] **Server owns freshness**: Staleness threshold = 15 minutes. Client re-fetches on: mount, realtime broadcast, reconnect, visibility change.
+- [ ] **Server-side validation**: All pool, pick, and scoring mutations must be validated server-side.
+- [ ] **Archive before write**: Round data archived to `tournament_score_rounds` before writing current score.
+- [ ] **Archive records exclude `round_status`**: Board-authorized rule to prevent circular dependencies.
+
+### Spectator Visibility
+
+- [ ] **Always surface freshness state**: Show users when data is in-flight or stale.
+- [ ] **Always surface lock state**: Show users when picks are locked.
+
+For detailed specifications, edge cases, and open questions, see [`docs/rules-spec.md`](./docs/rules-spec.md).
 
 ## Compound Engineering
 

--- a/docs/rules-spec.md
+++ b/docs/rules-spec.md
@@ -1,0 +1,274 @@
+# Fantasy Golf MVP — Rules Specification
+
+**Status:** Frozen as of OPS-49
+**Purpose:** Single authoritative source for MVP game rules. All implementation, tests, and UI reference this document.
+**Scope:** MVP only. Future features (playoff rules, season-long, ranking tiers) are explicitly excluded.
+
+---
+
+## 1. Pool Structure
+
+### 1.1 Entry Composition
+
+| Rule | Value | Source |
+|------|-------|--------|
+| Golfers per entry | Exactly `picks_per_entry` (default: 4, range: 1–10) | `pool.ts:validatePoolFormat`, `picks.ts:validatePickSubmission` |
+| Pool format | `best_ball` only | `pool.ts:VALID_FORMATS` |
+| Duplicate golfers | Not allowed within same entry | `picks.ts:validatePickSubmission` |
+
+**Constraint:** `picks_per_entry` is configured at pool creation and cannot be changed after the pool is created.
+
+---
+
+## 2. Scoring
+
+### 2.1 Core Algorithm: Best Ball, Hole-by-Hole
+
+For each round, the entry's score is the **lowest `scoreToPar`** among all **active** golfers in the entry.
+
+```
+Entry round score = min(scoreToPar of active golfers)
+Entry total score = sum(Entry round score for each completed round)
+```
+
+**Source:** `src/lib/scoring/domain.ts:computeEntryScore`
+
+### 2.2 Golfer Status Filtering
+
+| Status | Counts in scoring? | Notes |
+|--------|-------------------|-------|
+| `active` | Yes | Normal playing status |
+| `cut` | No (excluded after cut occurs) | Removed from tournament at cut line |
+| `withdrawn` | No (excluded after WD occurs) | Player voluntarily withdrew |
+| `dq` | Not modeled in types | External data may contain; treated as `withdrawn` if encountered |
+
+**Source:** `src/lib/scoring/domain.ts:isActiveGolfer` (status === 'active')
+
+### 2.3 Score Accumulation Rules
+
+1. **Round completion gating:** A round only counts toward the entry total if **all golfers** in the entry have `isComplete: true` for that round.
+2. **Partial rounds:** If any golfer in the entry has `isComplete: false` for a round, that round is skipped entirely.
+3. **Golfer drop after status change:** A golfer who is `cut` or `withdrawn` is excluded from best-ball calculation for all subsequent rounds, but their completed rounds still count.
+
+**Source:** `src/lib/scoring/domain.ts:computeEntryScore` (round-level `isComplete` gating at lines 90–95)
+
+### 2.4 Tiebreaker Order
+
+| Priority | Criterion | Direction | Source |
+|----------|-----------|----------|--------|
+| 1 | Total score | Lower is better | `domain.ts:rankEntries` |
+| 2 | Total birdies | Higher is better | `domain.ts:rankEntries` |
+| 3 | Shared rank | Both entries receive same rank | `domain.ts:rankEntries` |
+
+**Note:** If two entries have identical total score AND identical birdie count, they share a rank with no further tiebreak.
+
+### 2.5 Birdie Definition
+
+A birdie is any hole where `scoreToPar < 0` (i.e., one under par or better).
+
+**Source:** `src/lib/scoring/domain.ts:isBirdie` (line 39: `scoreToPar < 0`)
+
+---
+
+## 3. Pool Lifecycle
+
+### 3.1 Status Transitions
+
+```
+open → live → complete → open | archived
+```
+
+No other transitions are allowed.
+
+**Source:** `src/lib/pool.ts:STATUS_TRANSITIONS`, `pool.ts:canTransitionStatus`
+
+### 3.2 Auto-Lock Behavior
+
+An `open` pool automatically transitions to `live` when the deadline passes (as determined by `shouldAutoLock`).
+
+**Source:** `src/lib/picks.ts:shouldAutoLock`
+
+---
+
+## 4. Picks Locking
+
+### 4.1 Lock Condition
+
+A pool is **locked** when EITHER of these is true:
+1. Pool status is not `open`
+2. Current time >= lock instant
+
+**Source:** `src/lib/picks.ts:isPoolLocked`
+
+### 4.2 Lock Instant Calculation
+
+The lock instant is **midnight (00:00) in the pool's configured timezone** on the deadline date.
+
+- Input: `deadline` (ISO date string like `2026-04-10`) and `timezone` (IANA timezone like `America/New_York`)
+- The deadline represents a local date in the pool's timezone
+- The lock instant is computed via iterative offset resolution (up to 3 iterations) to handle DST transitions
+- UTC midnight in the pool timezone = lock time
+
+**Source:** `src/lib/picks.ts:getTournamentLockInstant`
+
+**Example:**
+```
+deadline = "2026-04-09T00:00:00+00:00"
+timezone = "America/New_York"
+lockAt = 2026-04-09T04:00:00.000Z  (midnight ET = 4am UTC)
+```
+
+### 4.3 Locked Pool Behavior
+
+- All pick mutations are rejected with error: "This pool is locked. Picks can no longer be changed."
+- Picks can no longer be changed for any user (including commissioner)
+- Spectators can still view the leaderboard
+
+**Source:** `src/lib/picks.ts:validatePickSubmission`
+
+### 4.4 Picks Lock for All Users
+
+Commissioner picks are subject to the same locking rules as player picks.
+
+**Source:** `src/lib/picks.ts:isCommissionerPoolLocked`
+
+---
+
+## 5. Golfer Status Handling
+
+### 5.1 Cut
+
+- Occurs when a golfer fails to make the cut line
+- Post-cut, the golfer's scores are archived but the golfer is excluded from best-ball calculation
+- An entry with 1 cut golfer + 3 active golfers still uses best ball among the 3 active golfers for remaining rounds
+
+### 5.2 Withdrawn (WD)
+
+- Occurs when a golfer voluntarily withdraws mid-tournament
+- Post-WD, the golfer is excluded from best-ball calculation
+- Same treatment as cut for scoring purposes
+
+### 5.3 Disqualified (DQ)
+
+- Not explicitly modeled in `GolferStatus` type (`'active' | 'withdrawn' | 'cut'`)
+- If external data contains `dq` status, it should be treated equivalently to `withdrawn`
+- **Open question:** DQ is not explicitly tested; clarify if DQ should be treated differently than WD
+
+### 5.4 Incomplete Round (Thru < 18)
+
+- When a golfer has `thru < 18` (round in progress), `isComplete: false`
+- Per round-gating rule (2.3), incomplete rounds do not contribute to the entry score
+- This means a round where any entry golfer is mid-round does not count
+
+---
+
+## 6. Playoff Handling
+
+**Playoff holes do NOT count toward MVP scoring.**
+
+The scoring system only processes regulation rounds (1–18 holes). Playoff holes are not modeled in `TournamentScore` or `TournamentScoreRound` and are excluded from:
+- Score accumulation
+- Leaderboard rankings
+- Birdie counts
+
+---
+
+## 7. Spectator Visibility
+
+### 7.1 Data Freshness
+
+| Threshold | Value | Behavior |
+|-----------|-------|---------|
+| Staleness threshold | 15 minutes | Data older than 15 min is considered stale |
+| Server-side | Auto-refresh | Cron job or manual refresh updates scores |
+| Client-side | Re-fetch triggers | Re-fetch on: mount, broadcast, reconnect, visibility change |
+
+**Source:** `src/app/api/leaderboard/[poolId]/route.ts`, `CLAUDE.md`
+
+### 7.2 In-Progress Round Display
+
+Spectators see in-progress data based on last refresh. There is no real-time push; the UI polls on visibility change.
+
+---
+
+## 8. Archive Rules
+
+### 8.1 Archive Before Write
+
+Before writing current score data, the system archives all round-level data to `tournament_score_rounds`.
+
+**Source:** `src/lib/scoring-queries.ts:upsertTournamentScore`
+
+### 8.2 Archive Record Exclusions
+
+Archive records (`tournament_score_rounds`) must **NOT** include `round_status`.
+
+This is a Board-authorized rule to prevent circular dependencies with leaderboard state.
+
+**Source:** `src/lib/scoring-queries.ts` (test at `scoring-queries.test.ts:109`), `audit.ts`
+
+---
+
+## 9. Edge Case Matrix
+
+### 9.1 Scoring Edge Cases
+
+| Scenario | Entry Golfers | Round 1 | Round 2 | Expected Score | Birdies | Notes |
+|----------|--------------|---------|---------|----------------|---------|-------|
+| Normal | g1(-1), g2(-1), g3(0), g4(+1) | Complete | Complete | -2 | 2 | Best ball each round |
+| Cut mid-tournament | g1(-1,cut), g2(-1,+1), g3(0,+1), g4(+1,0) | Complete | Complete | -1 | 1 | g1 post-cut excluded from R2 |
+| WD mid-tournament | g1(-1,wd), g2(-1,-1), g3(0,0), g4(+1,+1) | Complete | Complete | -2 | 2 | g1 post-WD excluded from R2 |
+| Partial round | g1(-1, incomplete), g2(-1,+1), g3(0,+1), g4(+1,0) | R1 only | — | -1 | 1 | R2 skipped (not all complete) |
+| All cut after R1 | g1(cut), g2(cut), g3(cut), g4(cut) | Complete | — | 0 | 0 | No valid R2, score is 0 |
+| Entry has no active golfers | all withdrawn/cut | Complete | Complete | null | 0 | totalScore is null, ranks last |
+| Tie score, tie birdies | e1: -2 total, 2 birdies; e2: -2 total, 2 birdies | — | — | -2 each | 2 each | Shared rank 1 |
+
+### 9.2 Leaderboard Edge Cases
+
+| Scenario | Display Behavior |
+|----------|-----------------|
+| Null totalScore | Entry shown at bottom with `—` or `null` |
+| Shared rank | Both entries show same rank number; next rank skips (e.g., 1, 1, 3) |
+| In-progress round | Last completed round only; in-progress not reflected |
+| Stale data (>15 min) | UI shows stale indicator |
+
+### 9.3 Locking Edge Cases
+
+| Scenario | Locked? | Notes |
+|----------|---------|-------|
+| Open, deadline in future | No | Normal state |
+| Open, deadline in past | Yes | Auto-locked via `shouldAutoLock` |
+| Live pool | Yes | Locked regardless of deadline |
+| Complete pool | Yes | Locked regardless of deadline |
+| Archived pool | Yes | Locked; no reopening |
+| Invalid deadline string | Yes | Failsafe: lock the pool |
+| DST transition day | Correct | Iterative offset resolution handles this |
+
+---
+
+## 10. Out of Scope for MVP
+
+The following are **explicitly excluded** from MVP rules and should not be implemented unless added as a separate story:
+
+- Playoff hole scoring and tiebreaker
+- Season-long points or rolling standings
+- Ranking tier rules beyond documenting future compatibility
+- Multiple pool formats beyond `best_ball`
+- Multi-entry support (one entry per user per pool is enforced by absence of multi-entry logic)
+- Real-time push updates (polling only)
+- Custom tiebreaker beyond birdies
+- Reskin or configurable picks-per-entry after pool creation
+
+---
+
+## 11. Open Questions
+
+| # | Question | Impact | Resolution Needed From |
+|---|----------|--------|----------------------|
+| 1 | How should `dq` status be handled? Should it be treated like `withdrawn` or flagged differently? | Low (unlikely in MVP sample data) | Product Planner |
+| 2 | If all 4 golfers in an entry are cut/WD before any round completes, should the entry show `null` score or be excluded? | Medium (affects UI display) | Product Planner |
+| 3 | Is the archive record exclusion (`round_status` not in archive) intentional and permanent, or a temporary workaround? | High (affects data model) | Board/Technical |
+
+---
+
+*This document is the single source of truth for MVP rules. When implementation and this document disagree, this document should be updated first and implementation adjusted to match.*

--- a/docs/superpowers/plans/2026-04-25-ops-49-mvp-rules-freeze.md
+++ b/docs/superpowers/plans/2026-04-25-ops-49-mvp-rules-freeze.md
@@ -1,0 +1,158 @@
+# OPS-49: Freeze MVP Rules and Edge Cases — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finalize the MVP rules freeze by updating CLAUDE.md with a checklist-style Critical Rules section that links to `docs/rules-spec.md`, and post the 3 open questions to the issue for Product Planner resolution.
+
+**Architecture:** Documentation-only change. The rules spec at `docs/rules-spec.md` is the authoritative source; CLAUDE.md becomes a quick-reference checklist that links to it.
+
+**Tech Stack:** Markdown, git
+
+---
+
+## Task 1: Update CLAUDE.md Critical Rules Section
+
+**Files:**
+- Modify: `CLAUDE.md:67-74`
+
+- [ ] **Step 1: Read current Critical Rules section**
+
+Confirm the current content at CLAUDE.md lines 67-74 matches:
+```
+## Critical Rules
+
+- **Do not** couple scoring logic to Next.js handlers, React components, or Supabase SDK calls
+- **Do not** make client UI the source of truth for auth, deadlines, or scoring state
+- **Leaderboard freshness model**: the server owns staleness via a configurable threshold (currently 15m). The API triggers an upstream refresh on fetch when data is older than the threshold. The client re-fetches on: mount, realtime `scores` broadcasts, realtime channel reconnect (`SUBSCRIBED` after drop), and tab visibility change to `visible`. No fixed-interval polling. Always surface freshness/refreshing state in the UI so users can see when data is in-flight or stale.
+- Keep business rules in `src/lib/scoring.ts` and pure utilities; not in page components
+- Use server-side validation for all pool, pick, and scoring mutations
+- Preserve visible freshness and lock-state messaging in UI
+```
+
+- [ ] **Step 2: Replace Critical Rules section with enhanced version**
+
+Replace the existing section (lines 67-74) with this enhanced version:
+
+```markdown
+## Critical Rules
+
+These are the non-negotiable rules for the MVP. The full authoritative specification is at [`docs/rules-spec.md`](./docs/rules-spec.md).
+
+### Game Rules
+
+- [ ] **Entry size**: Exactly `picks_per_entry` golfers (default: 4). No duplicates within an entry.
+- [ ] **Best-ball scoring**: Lowest `scoreToPar` among active golfers per round, summed across completed rounds.
+- [ ] **Tiebreaker**: Total score (lower is better) → total birdies (higher is better) → shared rank.
+- [ ] **Active golfers only**: `cut` and `withdrawn` golfers are excluded from best-ball calculation after they occur.
+- [ ] **Round completion gating**: A round only counts if ALL golfers in the entry have `isComplete: true`.
+- [ ] **Playoff holes**: Do NOT count toward MVP scoring.
+
+### Locking Rules
+
+- [ ] **Pick locks at pool deadline**: Lock instant = midnight (00:00) in the pool's configured timezone on the deadline date.
+- [ ] **Pool status lock**: Non-`open` pools are always locked regardless of deadline.
+- [ ] **All users subject to lock**: Commissioner picks lock the same as player picks.
+
+### Data Architecture
+
+- [ ] **Scoring logic is pure**: Keep in `src/lib/scoring.ts` and `src/lib/scoring/domain.ts`. No coupling to handlers, components, or Supabase SDK.
+- [ ] **Server owns freshness**: Staleness threshold = 15 minutes. Client re-fetches on: mount, realtime broadcast, reconnect, visibility change.
+- [ ] **Server-side validation**: All pool, pick, and scoring mutations must be validated server-side.
+- [ ] **Archive before write**: Round data archived to `tournament_score_rounds` before writing current score.
+- [ ] **Archive records exclude `round_status`**: Board-authorized rule to prevent circular dependencies.
+
+### Spectator Visibility
+
+- [ ] **Always surface freshness state**: Show users when data is in-flight or stale.
+- [ ] **Always surface lock state**: Show users when picks are locked.
+
+For detailed specifications, edge cases, and open questions, see [`docs/rules-spec.md`](./docs/rules-spec.md).
+```
+
+- [ ] **Step 3: Verify markdown renders correctly**
+
+Open `CLAUDE.md` and visually confirm:
+- The checklist format renders with checkboxes
+- The link to `docs/rules-spec.md` is correct
+- No markdown syntax errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "OPS-49: Enhance CLAUDE.md Critical Rules with checklist and link to rules spec
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 2: Post Open Questions to Issue for Product Planner Resolution
+
+**Files:**
+- None (API comment only)
+
+- [ ] **Step 1: Verify the 3 open questions from rules-spec.md Section 11**
+
+These are the 3 open questions that need Product Planner input:
+
+1. **DQ status handling**: How should `dq` status be handled? Should it be treated like `withdrawn` or flagged differently?
+2. **All-cut entry display**: If all 4 golfers in an entry are cut/WD before any round completes, should the entry show `null` score or be excluded from leaderboard?
+3. **Archive `round_status` exclusion**: Is the rule "archive records must NOT include `round_status`" intentional and permanent, or a temporary workaround?
+
+- [ ] **Step 2: Post comment to OPS-49 issue**
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_API_URL/api/issues/OPS-49/comments" \
+  -d '{
+    "body": "## 3 Open Questions Requiring Product Planner Resolution\n\nThese questions are documented in [`docs/rules-spec.md#open-questions`](./issues/OPS-49#document-rules-spec) Section 11. Please advise on each:\n\n### 1. DQ Status Handling\n**Question**: How should `dq` (disqualified) status be handled? Should it be treated the same as `withdrawn` (excluded from best-ball after occurrence) or flagged differently?\n\n**Impact**: Low (unlikely in MVP sample data)\n\n### 2. All-Cut Entry Display\n**Question**: If all 4 golfers in an entry are cut/WD before any round completes, should the entry show a `null` score (displayed as \"—\") or be excluded from the leaderboard entirely?\n\n**Impact**: Medium (affects UI display logic)\n\n### 3. Archive round_status Exclusion\n**Question**: The rule \"archive records (`tournament_score_rounds`) must NOT include `round_status`\" was a Board-authorized decision. Is this intentional and permanent, or a temporary workaround that should be revisited?\n\n**Impact**: High (affects data model design)\n\n---\n\nPlease resolve these so the implementation can proceed cleanly."
+  }'
+```
+
+Expected: `201 Created` response with comment object.
+
+- [ ] **Step 3: Verify comment was posted**
+
+```bash
+curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  "$PAPERCLIP_API_URL/api/issues/OPS-49/comments" | grep -c "Open Questions"
+```
+
+Expected: `1` (or more if other comments exist)
+
+---
+
+## Verification
+
+After completing all tasks:
+
+1. **CLAUDE.md**: Open the file and verify the Critical Rules section has:
+   - Checklist format with `[ ]` checkboxes
+   - All 6 game rules listed
+   - All 6 locking/data architecture rules listed
+   - Both spectator visibility rules listed
+   - Link to `docs/rules-spec.md` at the bottom
+
+2. **Issue comment**: Verify the open questions comment was posted by checking the issue comments API.
+
+3. **Git log**: Verify the commit exists:
+   ```bash
+   git log --oneline -1
+   ```
+   Expected: `OPS-49: Enhance CLAUDE.md Critical Rules...`
+
+---
+
+## Dependencies
+
+- Task 2 (posting open questions) can proceed independently but is logically after Task 1 since it references the rules spec document.
+- The 3 open questions block the rules spec from being truly "frozen" — Product Planner input is required before the spec can be considered complete.
+
+## Post-Completion
+
+Once both tasks are complete and the open questions are resolved by Product Planner:
+- Update `docs/rules-spec.md` Section 11 with the resolutions
+- The issue can then be marked as done

--- a/docs/superpowers/plans/2026-04-25-ops-50-scoring-engine-rebuild-plan.md
+++ b/docs/superpowers/plans/2026-04-25-ops-50-scoring-engine-rebuild-plan.md
@@ -1,0 +1,755 @@
+# OPS-50: Scoring Engine Rebuild Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the scoring engine to use hole-by-hole best ball from `tournament_holes` data instead of aggregate golfer score shortcuts.
+
+**Architecture:** The scoring engine is rebuilt around a new `tournament_holes` table that stores per-hole strokes. `buildGolferRoundScoresMap()` is rewritten to produce one `PlayerHoleScore` entry per stored hole (with `roundId` + `holeId`). `computeEntryScore()` is updated to index by `(roundId, holeId)` pairs, compute best-ball per hole, and sum only when all active golfers have completed the round.
+
+**Tech Stack:** TypeScript, Vitest, Supabase (Postgres), Next.js API routes
+
+---
+
+## File Structure
+
+```
+src/lib/
+  scoring/
+    domain.ts          # PlayerHoleScore, computeEntryScore(), rankEntries()
+  scoring.ts           # buildGolferRoundScoresMap(), rankEntries() entry point
+  scoring-queries.ts   # getTournamentHolesForGolfers(), upsertTournamentHoles()
+  supabase/
+    types.ts           # TournamentHole type
+supabase/migrations/
+  YYYYMMDDHHMMSS_create_tournament_holes.sql
+src/lib/__tests__/
+  domain-scoring.test.ts    # existing — add holeId tests + hole-level tests
+  scoring.test.ts           # existing — update for new data shape
+  scoring-queries.test.ts   # new — test tournament_holes queries
+```
+
+---
+
+## Task 1: Add `holeId` to `PlayerHoleScore` interface
+
+**Files:**
+- Modify: `src/lib/scoring/domain.ts:3-8`
+- Test: `src/lib/__tests__/domain-scoring.test.ts`
+
+- [ ] **Step 1: Update `PlayerHoleScore` interface**
+
+```typescript
+// src/lib/scoring/domain.ts:3-8 — BEFORE
+export interface PlayerHoleScore {
+  roundId: number
+  scoreToPar: number | null
+  status: GolferStatus
+  isComplete: boolean
+}
+
+// src/lib/scoring/domain.ts — AFTER
+export interface PlayerHoleScore {
+  roundId: number
+  holeId: number         // 1-18 — added for hole-level indexing
+  scoreToPar: number | null
+  status: GolferStatus
+  isComplete: boolean
+}
+```
+
+- [ ] **Step 2: Update `makePlayerHoleScore` helper in test file**
+
+```typescript
+// src/lib/__tests__/domain-scoring.test.ts:14-16 — BEFORE
+function makePlayerHoleScore(roundId: number, scoreToPar: number, status: GolferStatus, isComplete: boolean): PlayerHoleScore {
+  return { roundId, scoreToPar: scoreToPar as number, status, isComplete }
+}
+
+// src/lib/__tests__/domain-scoring.test.ts — AFTER
+function makePlayerHoleScore(roundId: number, holeId: number, scoreToPar: number, status: GolferStatus, isComplete: boolean): PlayerHoleScore {
+  return { roundId, holeId, scoreToPar: scoreToPar as number, status, isComplete }
+}
+```
+
+- [ ] **Step 3: Update all existing test calls to pass `holeId`**
+
+In `domain-scoring.test.ts`, every call to `makePlayerHoleScore` currently passes 4 args. Add `1` as the second argument (holeId = 1) to all existing calls, then add new tests with varying holeIds.
+
+Example update for the first test case:
+```typescript
+// src/lib/__tests__/domain-scoring.test.ts:40-44 — update each call
+['g1', [makePlayerHoleScore(1, 1, -2, 'active', true)]],   // was (1, -2, ...)
+['g2', [makePlayerHoleScore(1, 1, -1, 'active', true)]],  // was (1, -1, ...)
+['g3', [makePlayerHoleScore(1, 1, 0, 'active', true)]],    // was (1, 0, ...)
+['g4', [makePlayerHoleScore(1, 1, 1, 'active', true)]],    // was (1, 1, ...)
+```
+
+Run: `cd /paperclip/instances/default/projects/db1bfeae-22d7-4a31-80a7-8ca5e5ae3bf6/c7451134-3dc7-4349-a014-2d43a4d0fff3/fantasy-golf && npm test -- --run src/lib/__tests__/domain-scoring.test.ts`
+Expected: PASS (all existing tests still pass with updated helper)
+
+- [ ] **Step 4: Add holeId to `EntryHoleResult` and `GolferRoundScoresMap` usages**
+
+The `EntryHoleResult` interface also references hole-level data. Update it to include `holeId`:
+```typescript
+// src/lib/scoring/domain.ts:10-14 — BEFORE
+export interface EntryHoleResult {
+  roundId: number
+  bestBallScore: number | null
+  isComplete: boolean
+}
+
+// src/lib/scoring/domain.ts — AFTER
+export interface EntryHoleResult {
+  roundId: number
+  holeId: number
+  bestBallScore: number | null
+  isComplete: boolean
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /paperclip/instances/default/projects/db1bfeae-22d7-4a31-80a7-8ca5e5ae3bf6/c7451134-3dc7-4349-a014-2d43a4d0fff3/fantasy-golf
+git add src/lib/scoring/domain.ts src/lib/__tests__/domain-scoring.test.ts
+git commit -m "ops-50: add holeId to PlayerHoleScore and EntryHoleResult interfaces
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 2: Rewrite `computeEntryScore()` for hole-level best ball
+
+**Files:**
+- Modify: `src/lib/scoring/domain.ts:43-121`
+
+- [ ] **Step 1: Write the failing test for hole-level scoring**
+
+```typescript
+// src/lib/__tests__/domain-scoring.test.ts — add new test
+describe('computeEntryScore hole-level', () => {
+  it('normal round — best ball per hole summed', () => {
+    // 4 golfers, each has 18 holes with varying scores
+    // g1 is best on 10 holes (-1 each), g2 best on 8 holes (-2 each)
+    // Entry score = 10 * (-1) + 8 * (-2) = -10 - 16 = -26
+    const scores = makeGolferRoundScoresMapentries([
+      ['g1', Array.from({ length: 18 }, (_, i) => makePlayerHoleScore(1, i + 1, -1, 'active', true))],
+      ['g2', Array.from({ length: 18 }, (_, i) => makePlayerHoleScore(1, i + 1, -2, 'active', true))],
+      ['g3', Array.from({ length: 18 }, (_, i) => makePlayerHoleScore(1, i + 1, 0, 'active', true))],
+      ['g4', Array.from({ length: 18 }, (_, i) => makePlayerHoleScore(1, i + 1, 1, 'active', true))],
+    ])
+
+    const result = computeEntryScore(scores, ['g1', 'g2', 'g3', 'g4'])
+
+    // Best ball each hole: g2's -2 for first 8 holes, g1's -1 for next 10
+    // Sum = 8 * (-2) + 10 * (-1) = -16 + -10 = -26
+    expect(result.totalScore).toBe(-26)
+    expect(result.totalBirdies).toBe(18)  // all holes are birdie or better (-1 or -2)
+    expect(result.completedHoles).toBe(18)
+  })
+
+  it('round with missing golfer — skipped', () => {
+    // g1 complete 18 holes, g2 only has 10 holes (incomplete round)
+    // Entire round should be skipped
+    const scores = makeGolferRoundScoresMapentries([
+      ['g1', Array.from({ length: 18 }, (_, i) => makePlayerHoleScore(1, i + 1, -1, 'active', true))],
+      ['g2', Array.from({ length: 10 }, (_, i) => makePlayerHoleScore(1, i + 1, -2, 'active', true))],
+      ['g3', Array.from({ length: 18 }, (_, i) => makePlayerHoleScore(1, i + 1, 0, 'active', true))],
+      ['g4', Array.from({ length: 18 }, (_, i) => makePlayerHoleScore(1, i + 1, 1, 'active', true))],
+    ])
+
+    const result = computeEntryScore(scores, ['g1', 'g2', 'g3', 'g4'])
+
+    // Round incomplete — no holes count
+    expect(result.totalScore).toBe(null)
+    expect(result.completedHoles).toBe(0)
+  })
+})
+```
+
+Run: `npm test -- --run src/lib/__tests__/domain-scoring.test.ts`
+Expected: FAIL on the new tests (function doesn't index by holeId yet)
+
+- [ ] **Step 2: Rewrite `computeEntryScore()` to index by (roundId, holeId)**
+
+```typescript
+// src/lib/scoring/domain.ts:43-121 — REPLACE with:
+export function computeEntryScore(
+  golferRoundScores: GolferRoundScoresMap,
+  activeGolferIds: string[]
+): EntryScoreAccumulator {
+  let totalScore: number | null = 0
+  let totalBirdies = 0
+  let completedHoles = 0
+
+  const activeSet = new Set(activeGolferIds)
+
+  // Build hole-level index: "roundId-holeId" -> entries from all golfers
+  const holesIndex = new Map<string, Array<{ golferId: string; scoreToPar: number | null; isComplete: boolean; status: GolferStatus }>>()
+
+  for (const [golferId, rounds] of golferRoundScores) {
+    for (const round of rounds) {
+      const holeKey = `${round.roundId}-${round.holeId}`
+      if (!holesIndex.has(holeKey)) {
+        holesIndex.set(holeKey, [])
+      }
+      holesIndex.get(holeKey)!.push({
+        golferId,
+        scoreToPar: round.scoreToPar,
+        isComplete: round.isComplete,
+        status: round.status,
+      })
+    }
+  }
+
+  // Determine which rounds are complete for all active golfers
+  // A round is complete only when ALL active golfers have all 18 holes with isComplete=true
+  const roundCompleteness = new Map<number, boolean>()
+  for (const [holeKey, entries] of holesIndex) {
+    const roundId = parseInt(holeKey.split('-')[0])
+    const allComplete = entries.every(e => e.isComplete)
+    const current = roundCompleteness.get(roundId)
+    roundCompleteness.set(roundId, current === undefined ? allComplete : current && allComplete)
+  }
+
+  // Compute best ball per hole, sum only complete rounds
+  for (const [holeKey, entries] of holesIndex) {
+    const roundId = parseInt(holeKey.split('-')[0])
+
+    // Skip incomplete rounds
+    if (!roundCompleteness.get(roundId)) continue
+
+    // Filter to active golfers only (status === 'active')
+    const activeEntries = entries.filter(e => activeSet.has(e.golferId) && e.status === 'active')
+    if (activeEntries.length === 0) continue
+
+    const validScores = activeEntries
+      .map(e => e.scoreToPar)
+      .filter((s): s is number => s !== null)
+
+    if (validScores.length === 0) continue
+
+    const bestBall = Math.min(...validScores)
+    totalScore = (totalScore !== null ? totalScore : 0) + bestBall
+    completedHoles++
+
+    if (isBirdie(bestBall)) totalBirdies++
+  }
+
+  return {
+    totalScore: totalScore === 0 && completedHoles === 0 ? null : totalScore,
+    totalBirdies,
+    completedHoles,
+    activeGolferIds,
+  }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `npm test -- --run src/lib/__tests__/domain-scoring.test.ts`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/scoring/domain.ts src/lib/__tests__/domain-scoring.test.ts
+git commit -m "ops-50: rewrite computeEntryScore for hole-level best ball
+
+Now indexes by (roundId, holeId) pairs and sums best-ball per hole.
+Round is only counted when all active golfers have complete 18-hole data.
+Active golfer filtering uses status === 'active'.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 3: Add `TournamentHole` type and database migration
+
+**Files:**
+- Modify: `src/lib/supabase/types.ts`
+- Create: `supabase/migrations/YMMddHHMMSS_create_tournament_holes.sql`
+
+- [ ] **Step 1: Add `TournamentHole` type to supabase types**
+
+```typescript
+// src/lib/supabase/types.ts — ADD after TournamentScoreRound interface
+export interface TournamentHole {
+  id?: string
+  golfer_id: string
+  tournament_id: string
+  round_id: number
+  hole_id: number
+  strokes: number
+  par: number
+  score_to_par: number
+  updated_at?: string
+}
+```
+
+- [ ] **Step 2: Write migration for `tournament_holes` table**
+
+```sql
+-- supabase/migrations/YYYYMMDDHHMMSS_create_tournament_holes.sql
+
+CREATE TABLE tournament_holes (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  golfer_id TEXT NOT NULL,
+  tournament_id TEXT NOT NULL,
+  round_id INTEGER NOT NULL CHECK (round_id BETWEEN 1 AND 4),
+  hole_id INTEGER NOT NULL CHECK (hole_id BETWEEN 1 AND 18),
+  strokes INTEGER NOT NULL,
+  par INTEGER NOT NULL,
+  score_to_par INTEGER NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(golfer_id, tournament_id, round_id, hole_id)
+);
+
+CREATE INDEX idx_tournament_holes_lookup
+  ON tournament_holes(tournament_id, golfer_id, round_id);
+
+CREATE INDEX idx_tournament_holes_tournament
+  ON tournament_holes(tournament_id, round_id, hole_id);
+
+ALTER TABLE tournament_holes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "tournament_holes_service_role_all"
+  ON tournament_holes FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON tournament_holes TO service_role;
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/supabase/types.ts supabase/migrations/
+git commit -m "ops-50: add TournamentHole type and tournament_holes migration
+
+TournamentHole stores per-hole strokes with (golfer_id, tournament_id, round_id, hole_id)
+as the unique key. score_to_par = strokes - par.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 4: Add query functions for `tournament_holes`
+
+**Files:**
+- Modify: `src/lib/scoring-queries.ts`
+- Create: `src/lib/__tests__/scoring-queries.test.ts`
+
+- [ ] **Step 1: Write failing tests for new query functions**
+
+```typescript
+// src/lib/__tests__/scoring-queries.test.ts — ADD new describe block
+describe('tournament_holes queries', () => {
+  it('getTournamentHolesForGolfers returns holes grouped by golfer', async () => {
+    // Mock supabase client
+    const mockSupabase = {
+      from: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+    }
+    
+    // Setup mock data
+    const mockHoles = [
+      { golfer_id: 'g1', tournament_id: 't1', round_id: 1, hole_id: 1, strokes: 4, par: 4, score_to_par: 0 },
+      { golfer_id: 'g1', tournament_id: 't1', round_id: 1, hole_id: 2, strokes: 3, par: 4, score_to_par: -1 },
+    ]
+    
+    mockSupabase.select.mockReturnThis()
+    mockSupabase.eq.mockReturnThis()
+    mockSupabase.in.mockReturnThis()
+    mockSupabase.order.mockReturnValue({
+      data: mockHoles,
+      error: null,
+    })
+    
+    const result = await getTournamentHolesForGolfers(mockSupabase as any, 't1', ['g1', 'g2'])
+    
+    expect(mockSupabase.from).toHaveBeenCalledWith('tournament_holes')
+    expect(result.get('g1')?.length).toBe(2)
+    expect(result.get('g1')?.[0].score_to_par).toBe(0)
+  })
+
+  it('upsertTournamentHoles writes multiple holes', async () => {
+    const mockSupabase = {
+      from: vi.fn().mockReturnThis(),
+      upsert: vi.fn().mockReturnThis(),
+    }
+    
+    mockSupabase.upsert.mockReturnValue({ error: null })
+    
+    const holes: TournamentHole[] = [
+      { golfer_id: 'g1', tournament_id: 't1', round_id: 1, hole_id: 1, strokes: 4, par: 4, score_to_par: 0 },
+    ]
+    
+    const result = await upsertTournamentHoles(mockSupabase as any, holes)
+    expect(result.error).toBe(null)
+    expect(mockSupabase.upsert).toHaveBeenCalled()
+  })
+})
+```
+
+Run: `npm test -- --run src/lib/__tests__/scoring-queries.test.ts`
+Expected: FAIL (functions don't exist yet)
+
+- [ ] **Step 2: Add query functions to scoring-queries.ts**
+
+```typescript
+// src/lib/scoring-queries.ts — ADD before getScoresForTournament
+
+export async function getTournamentHolesForGolfers(
+  supabase: SupabaseClient,
+  tournamentId: string,
+  golferIds: string[]
+): Promise<Map<string, TournamentHole[]>> {
+  const { data, error } = await supabase
+    .from('tournament_holes')
+    .select('*')
+    .eq('tournament_id', tournamentId)
+    .in('golfer_id', golferIds)
+    .order('round_id', { ascending: true })
+    .order('hole_id', { ascending: true })
+
+  if (error) throw new Error(error.message)
+
+  const result = new Map<string, TournamentHole[]>()
+  for (const hole of (data as TournamentHole[]) || []) {
+    if (!result.has(hole.golfer_id)) {
+      result.set(hole.golfer_id, [])
+    }
+    result.get(hole.golfer_id)!.push(hole)
+  }
+  return result
+}
+
+export async function upsertTournamentHoles(
+  supabase: SupabaseClient,
+  holes: TournamentHole[]
+): Promise<{ error: string | null }> {
+  if (holes.length === 0) return { error: null }
+
+  const { error } = await supabase
+    .from('tournament_holes')
+    .upsert(holes, { onConflict: 'golfer_id,tournament_id,round_id,hole_id' })
+
+  if (error) return { error: error.message }
+  return { error: null }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `npm test -- --run src/lib/__tests__/scoring-queries.test.ts`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/scoring-queries.ts src/lib/__tests__/scoring-queries.test.ts
+git commit -m "ops-50: add getTournamentHolesForGolfers and upsertTournamentHoles to scoring-queries
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 5: Rewrite `buildGolferRoundScoresMap()` to use hole data
+
+**Files:**
+- Modify: `src/lib/scoring.ts:62-73`
+- Test: `src/lib/__tests__/scoring.test.ts`
+
+- [ ] **Step 1: Write failing test for new `buildGolferRoundScoresMap` signature**
+
+```typescript
+// src/lib/__tests__/scoring.test.ts — ADD new describe block
+describe('buildGolferRoundScoresMap with hole data', () => {
+  it('maps tournament holes to PlayerHoleScore entries with holeId', () => {
+    const holesByGolfer = new Map<string, TournamentHole[]>([
+      ['g1', [
+        { golfer_id: 'g1', tournament_id: 't1', round_id: 1, hole_id: 1, strokes: 4, par: 4, score_to_par: 0 },
+        { golfer_id: 'g1', tournament_id: 't1', round_id: 1, hole_id: 2, strokes: 3, par: 4, score_to_par: -1 },
+      ]],
+    ])
+    const statuses = new Map<string, GolferStatus>([['g1', 'active']])
+
+    const result = buildGolferRoundScoresMap(holesByGolfer, statuses)
+
+    expect(result.get('g1')?.length).toBe(2)
+    expect(result.get('g1')?.[0]).toMatchObject({ roundId: 1, holeId: 1, scoreToPar: 0, isComplete: true })
+    expect(result.get('g1')?.[1]).toMatchObject({ roundId: 1, holeId: 2, scoreToPar: -1, isComplete: true })
+  })
+})
+```
+
+Run: `npm test -- --run src/lib/__tests__/scoring.test.ts`
+Expected: FAIL (function signature doesn't match yet)
+
+- [ ] **Step 2: Update `buildGolferRoundScoresMap` function signature and body**
+
+```typescript
+// src/lib/scoring.ts:62-73 — REPLACE with:
+function buildGolferRoundScoresMap(
+  holesByGolfer: Map<string, TournamentHole[]>,
+  golferStatuses: Map<string, GolferStatus>
+): GolferRoundScoresMap {
+  const result: GolferRoundScoresMap = new Map()
+
+  for (const [golferId, holes] of holesByGolfer) {
+    const rounds: PlayerHoleScore[] = holes.map(hole => ({
+      roundId: hole.round_id,
+      holeId: hole.hole_id,
+      scoreToPar: hole.score_to_par,
+      status: golferStatuses.get(golferId) ?? 'active',
+      isComplete: true,  // only completed holes are stored
+    }))
+    result.set(golferId, rounds)
+  }
+
+  return result
+}
+```
+
+Also update the import to include `TournamentHole` and update the `rankEntries` function to use the new signature:
+
+```typescript
+// src/lib/scoring.ts — imports — ADD TournamentHole
+import type { TournamentHole } from './supabase/types'
+
+// src/lib/scoring.ts:75-82 — UPDATE rankEntries to use new map builder
+export function rankEntries(
+  entries: Entry[],
+  golferScores: Map<string, TournamentScore>,
+  completedRounds: number
+): (Entry & { totalScore: number | null; totalBirdies: number; rank: number; isTied: boolean })[] {
+  // First get hole data from tournament_holes for scoring
+  // For now, fall back to building from TournamentScore for backwards compat
+  const golferRoundScoresMap = buildGolferRoundScoresMapFromScores(golferScores)
+  return domainRankEntries(entries, golferRoundScoresMap, completedRounds) as (Entry & { totalScore: number | null; totalBirdies: number; rank: number; isTied: boolean })[]
+}
+
+// Keep old function for backwards compat during transition
+function buildGolferRoundScoresMapFromScores(tournamentScores: Map<string, TournamentScore>): GolferRoundScoresMap {
+  const result: GolferRoundScoresMap = new Map()
+  for (const [golferId, score] of tournamentScores) {
+    result.set(golferId, [{
+      roundId: score.round_id ?? 1,
+      holeId: 1,  // default — old path uses round-level
+      scoreToPar: score.total_score,
+      status: score.status,
+      isComplete: true,
+    }])
+  }
+  return result
+}
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `npm test -- --run src/lib/__tests__/scoring.test.ts src/lib/__tests__/domain-scoring.test.ts`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/scoring.ts src/lib/__tests__/scoring.test.ts
+git commit -m "ops-50: rewrite buildGolferRoundScoresMap for hole-level data
+
+New signature accepts holesByGolfer (Map of TournamentHole[]) and golferStatuses.
+Each TournamentHole becomes one PlayerHoleScore entry with roundId + holeId.
+Old buildGolferRoundScoresMapFromScores kept for backward compat during transition.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 6: Add edge-case and tiebreaker tests to domain-scoring.test.ts
+
+**Files:**
+- Modify: `src/lib/__tests__/domain-scoring.test.ts`
+
+- [ ] **Step 1: Write edge case tests**
+
+```typescript
+// src/lib/__tests__/domain-scoring.test.ts — ADD new describe block
+describe('computeEntryScore edge cases', () => {
+  it('all golfers cut — score is null', () => {
+    const scores = makeGolferRoundScoresMapentries([
+      ['g1', [
+        makePlayerHoleScore(1, 1, -1, 'cut', true),
+        makePlayerHoleScore(2, 1, -2, 'cut', true),
+      ]],
+      ['g2', [
+        makePlayerHoleScore(1, 1, 0, 'cut', true),
+        makePlayerHoleScore(2, 1, -1, 'cut', true),
+      ]],
+      ['g3', [
+        makePlayerHoleScore(1, 1, 1, 'cut', true),
+        makePlayerHoleScore(2, 1, 0, 'cut', true),
+      ]],
+      ['g4', [
+        makePlayerHoleScore(1, 1, 0, 'cut', true),
+        makePlayerHoleScore(2, 1, 1, 'cut', true),
+      ]],
+    ])
+
+    const result = computeEntryScore(scores, ['g1', 'g2', 'g3', 'g4'])
+
+    expect(result.totalScore).toBe(null)
+    expect(result.completedHoles).toBe(0)
+  })
+
+  it('shared rank when score AND birdies are equal', () => {
+    const scores = makeGolferRoundScoresMapentries([
+      ['g1', [makePlayerHoleScore(1, 1, -1, 'active', true)]],
+      ['g2', [makePlayerHoleScore(1, 1, -1, 'active', true)]],
+      ['g3', [makePlayerHoleScore(1, 1, -1, 'active', true)]],
+      ['g4', [makePlayerHoleScore(1, 1, -1, 'active', true)]],
+      ['g5', [makePlayerHoleScore(1, 1, -1, 'active', true)]],
+      ['g6', [makePlayerHoleScore(1, 1, -1, 'active', true)]],
+      ['g7', [makePlayerHoleScore(1, 1, -1, 'active', true)]],
+      ['g8', [makePlayerHoleScore(1, 1, -1, 'active', true)]],
+    ])
+
+    const entries: Entry[] = [
+      { id: 'e1', pool_id: 'p1', user_id: 'u1', golfer_ids: ['g1', 'g2', 'g3', 'g4'], total_birdies: 0, created_at: '', updated_at: '' },
+      { id: 'e2', pool_id: 'p1', user_id: 'u2', golfer_ids: ['g5', 'g6', 'g7', 'g8'], total_birdies: 0, created_at: '', updated_at: '' },
+    ]
+
+    const ranked = rankEntries(entries, scores, 1)
+
+    expect(ranked[0].rank).toBe(1)
+    expect(ranked[1].rank).toBe(1)
+    expect(ranked[0].isTied).toBe(true)
+    expect(ranked[1].isTied).toBe(true)
+  })
+
+  it('two rounds — only complete rounds count', () => {
+    // R1: all complete, R2: not all complete — only R1 counts
+    const scores = makeGolferRoundScoresMapentries([
+      ['g1', [
+        makePlayerHoleScore(1, 1, -1, 'active', true),
+        makePlayerHoleScore(2, 1, -2, 'active', false), // incomplete
+      ]],
+      ['g2', [
+        makePlayerHoleScore(1, 1, 0, 'active', true),
+        makePlayerHoleScore(2, 1, -1, 'active', true),
+      ]],
+      ['g3', [
+        makePlayerHoleScore(1, 1, 1, 'active', true),
+        makePlayerHoleScore(2, 1, 0, 'active', true),
+      ]],
+      ['g4', [
+        makePlayerHoleScore(1, 1, 0, 'active', true),
+        makePlayerHoleScore(2, 1, 1, 'active', true),
+      ]],
+    ])
+
+    const result = computeEntryScore(scores, ['g1', 'g2', 'g3', 'g4'])
+
+    // Only R1 counts (all complete) = -1
+    expect(result.totalScore).toBe(-1)
+    expect(result.completedHoles).toBe(1)
+  })
+})
+```
+
+Run: `npm test -- --run src/lib/__tests__/domain-scoring.test.ts`
+Expected: PASS
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/lib/__tests__/domain-scoring.test.ts
+git commit -m "ops-50: add edge case and tiebreaker tests for hole-level scoring
+
+Tests cover: all-cut score null, shared rank when score+birdies equal,
+two-round partial (only complete rounds count).
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 7: Update `rankEntries` to use hole-level scoring in live path
+
+**Files:**
+- Modify: `src/lib/scoring.ts`
+- Modify: `src/app/api/leaderboard/[poolId]/route.ts` (if it calls rankEntries)
+
+- [ ] **Step 1: Check where rankEntries is called**
+
+```bash
+cd /paperclip/instances/default/projects/db1bfeae-22d7-4a31-80a7-8ca5e5ae3bf6/c7451134-3dc7-4349-a014-2d43a4d0fff3/fantasy-golf
+grep -rn "rankEntries" src/ --include="*.ts" --include="*.tsx" | grep -v "__tests__" | grep -v "node_modules"
+```
+
+Run the grep and show output.
+
+- [ ] **Step 2: Add new overload of rankEntries that accepts hole data directly**
+
+```typescript
+// src/lib/scoring.ts — ADD new export
+export function rankEntriesWithHoles(
+  entries: Entry[],
+  holesByGolfer: Map<string, TournamentHole[]>,
+  golferStatuses: Map<string, GolferStatus>,
+  completedRounds: number
+): (Entry & { totalScore: number | null; totalBirdies: number; rank: number; isTied: boolean })[] {
+  const golferRoundScoresMap = buildGolferRoundScoresMap(holesByGolfer, golferStatuses)
+  return domainRankEntries(entries, golferRoundScoresMap, completedRounds) as (Entry & { totalScore: number | null; totalBirdies: number; rank: number; isTied: boolean })[]
+}
+```
+
+- [ ] **Step 3: Run all scoring tests**
+
+Run: `npm test -- --run src/lib/__tests__/domain-scoring.test.ts src/lib/__tests__/scoring.test.ts src/lib/__tests__/scoring-queries.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/scoring.ts
+git commit -m "ops-50: add rankEntriesWithHoles for hole-aware scoring path
+
+New function accepts holesByGolfer Map and golferStatuses Map directly,
+building GolferRoundScoresMap internally and calling domain rankEntries.
+This is the entry point for the live scoring path once tournament_holes is populated.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Verification
+
+Run the full test suite:
+```bash
+cd /paperclip/instances/default/projects/db1bfeae-22d7-4a31-80a7-8ca5e5ae3bf6/c7451134-3dc7-4349-a014-2d43a4d0fff3/fantasy-golf
+npm test -- --run
+```
+
+Expected: ALL tests pass (including pre-existing tests in all scoring files).
+
+---
+
+## Summary
+
+| Task | File | Status |
+|------|------|--------|
+| 1 | `domain.ts` — add holeId to PlayerHoleScore | TBD |
+| 2 | `domain.ts` — rewrite computeEntryScore for hole-level | TBD |
+| 3 | `supabase/types.ts` + migration | TBD |
+| 4 | `scoring-queries.ts` — hole query functions | TBD |
+| 5 | `scoring.ts` — rewrite buildGolferRoundScoresMap | TBD |
+| 6 | `domain-scoring.test.ts` — edge case tests | TBD |
+| 7 | `scoring.ts` — add rankEntriesWithHoles | TBD |

--- a/docs/superpowers/plans/2026-04-27-ops-52-slash-golf-scorecard-driven-scoring-flow-plan.md
+++ b/docs/superpowers/plans/2026-04-27-ops-52-slash-golf-scorecard-driven-scoring-flow-plan.md
@@ -1,0 +1,881 @@
+# OPS-52: Slash Golf Scorecard-Driven Scoring Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a clean multi-endpoint adapter layer for Slash Golf `/tournament`, `/leaderboard`, `/scorecard`, and `/stats` endpoints with 5-state status normalization, typed responses, and selective scorecard refresh strategy.
+
+**Architecture:** Extend `src/lib/slash-golf/client.ts` with four named endpoint functions. Add new types to `src/lib/slash-golf/types.ts`. Extend `GolferStatus` in `src/lib/supabase/types.ts` to a 5-state union. Add `upsertTournamentHoles` to `src/lib/scoring-queries.ts`. Document the call strategy separately.
+
+**Tech Stack:** TypeScript, Supabase JS client, Vitest
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|----------------|
+| `src/lib/slash-golf/types.ts` | Slash Golf API types only |
+| `src/lib/slash-golf/client.ts` | Endpoint fetch functions |
+| `src/lib/supabase/types.ts` | Database types |
+| `src/lib/scoring-queries.ts` | DB persistence for hole data |
+| `docs/superpowers/specs/ops-52-call-strategy.md` | Call strategy doc |
+
+---
+
+## Task 1: Add Types to `src/lib/slash-golf/types.ts`
+
+**Files:**
+- Modify: `src/lib/slash-golf/types.ts`
+
+- [ ] **Step 1: Read the existing types file**
+
+```bash
+cat src/lib/slash-golf/types.ts
+```
+
+- [ ] **Step 2: Add new types after the existing `RapidApiPlayer` interface**
+
+Append the following to `src/lib/slash-golf/types.ts`:
+
+```ts
+export type SlashGolferStatus = 'active' | 'withdrawn' | 'cut' | 'dq' | 'complete'
+
+export interface SlashTournamentMeta {
+  tournId: string
+  name: string
+  year: string
+  status: string
+  currentRound: number | null
+  courses: Array<{ courseId: string; courseName: string }>
+  format: string | null
+  date: string | null
+}
+
+export interface SlashLeaderboard {
+  tournId: string
+  year: string
+  status: string
+  roundId: number
+  roundStatus: string
+  timestamp: string
+  leaderboardRows: SlashGolferRow[]
+}
+
+export interface SlashGolferRow {
+  playerId: string
+  lastName: string
+  firstName: string
+  isAmateur: boolean
+  status: SlashGolferStatus
+  currentRound: number
+  total: string | { $numberInt: string }
+  currentRoundScore: string | { $numberInt: string }
+  position: string | null
+  totalStrokesFromCompletedRounds: string | null
+  rounds: SlashRound[]
+  thru: string | null
+  startingHole: number | null
+  currentHole: number | null
+  courseId: string | null
+  teeTime: string | null
+  teeTimeTimestamp: string | null
+}
+
+export interface SlashRound {
+  roundId: number
+  courseId: string
+  courseName: string
+  strokes: number | { $numberInt: string }
+  scoreToPar: number | { $numberInt: string }
+}
+
+export interface SlashHole {
+  holeId: number
+  par: number
+  strokes: number
+  scoreToPar: number
+}
+
+export interface SlashScorecard {
+  tournId: string
+  playerId: string
+  year: string
+  status: SlashGolferStatus
+  currentRound: number
+  holes: SlashHole[]
+}
+
+export interface SlashStats {
+  tournId: string
+  playerId: string
+  worldRank: number | null
+  projectedOWGR: number | null
+}
+```
+
+- [ ] **Step 3: Run TypeScript check**
+
+```bash
+npx tsc --noEmit src/lib/slash-golf/types.ts
+```
+
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/slash-golf/types.ts
+git commit -m "OPS-52: add Slash Golf API types — SlashTournamentMeta, SlashLeaderboard, SlashScorecard, SlashGolferStatus
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 2: Extend `GolferStatus` in `src/lib/supabase/types.ts`
+
+**Files:**
+- Modify: `src/lib/supabase/types.ts:5`
+
+- [ ] **Step 1: Read the existing `GolferStatus` line**
+
+```bash
+sed -n '5p' src/lib/supabase/types.ts
+```
+
+Expected: `export type GolferStatus = 'active' | 'withdrawn' | 'cut'`
+
+- [ ] **Step 2: Update `GolferStatus` to 5-state union**
+
+Modify line 5 of `src/lib/supabase/types.ts`:
+
+```ts
+export type GolferStatus = 'active' | 'withdrawn' | 'cut' | 'dq' | 'complete'
+```
+
+- [ ] **Step 3: Run TypeScript check on the types file**
+
+```bash
+npx tsc --noEmit src/lib/supabase/types.ts
+```
+
+Expected: No errors.
+
+- [ ] **Step 4: Run affected tests**
+
+```bash
+npx vitest run src/lib/__tests__/slash-golf-client.test.ts
+```
+
+Expected: PASS (existing tests unaffected — `GolferStatus` is not used in client test mocks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/supabase/types.ts
+git commit -m "OPS-52: extend GolferStatus to 5-state union (adds dq, complete)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 3: Add `getTournamentMeta` and `getLeaderboard` to `client.ts`
+
+**Files:**
+- Modify: `src/lib/slash-golf/client.ts`
+
+- [ ] **Step 1: Write the failing test for `getTournamentMeta` and `getLeaderboard`**
+
+Add to `src/lib/__tests__/slash-golf-client.test.ts`:
+
+```ts
+it('getTournamentMeta returns normalized tournament metadata', async () => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue({
+      orgId: '1',
+      year: '2026',
+      tournId: '014',
+      name: 'The Masters',
+      status: 'In Progress',
+      currentRound: 2,
+      courses: [{ courseId: '014', courseName: 'Augusta National Golf Club' }],
+      format: 'stroke',
+      date: '2026-04-10',
+    }),
+  }))
+
+  const meta = await getTournamentMeta('014', 2026)
+  expect(meta).toMatchObject({
+    tournId: '014',
+    name: 'The Masters',
+    year: '2026',
+    status: 'In Progress',
+    currentRound: 2,
+    courses: [{ courseId: '014', courseName: 'Augusta National Golf Club' }],
+  })
+})
+
+it('getLeaderboard returns normalized leaderboard with round status', async () => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue({
+      orgId: '1',
+      year: '2026',
+      tournId: '014',
+      status: 'In Progress',
+      roundId: 2,
+      roundStatus: 'In Progress',
+      timestamp: '2026-04-10T15:23:33.217000',
+      leaderboardRows: [
+        { playerId: '22405', lastName: 'Rose', firstName: 'Justin', isAmateur: false, status: 'active' },
+      ],
+    }),
+  }))
+
+  const board = await getLeaderboard('014', 2026)
+  expect(board.tournId).toBe('014')
+  expect(board.roundStatus).toBe('In Progress')
+  expect(board.leaderboardRows).toHaveLength(1)
+  expect(board.leaderboardRows[0].status).toBe('active')
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run src/lib/__tests__/slash-golf-client.test.ts 2>&1 | grep -E "(FAIL|getTournamentMeta|getLeaderboard)"
+```
+
+Expected: FAIL — `getTournamentMeta is not defined` or `getLeaderboard is not defined`.
+
+- [ ] **Step 3: Add `getTournamentMeta` and `getLeaderboard` to client.ts**
+
+Add before the closing of `client.ts`. Use the same BASE_URL and header pattern as existing functions:
+
+```ts
+export async function getTournamentMeta(tournamentId: string, year?: number): Promise<SlashTournamentMeta> {
+  const params = new URLSearchParams({ orgId: '1', tournId: tournamentId, ...(year && { year: year.toString() }) })
+  const res = await fetch(`${BASE_URL}/tournament?${params}`, {
+    headers: { 'X-RapidAPI-Key': process.env.SLASH_GOLF_API_KEY ?? '' },
+    next: { revalidate: 3600 }
+  })
+  if (!res.ok) throw new Error('Failed to fetch tournament metadata')
+  const raw = await res.json()
+  return {
+    tournId: typeof raw.tournId === 'string' ? raw.tournId : '',
+    name: typeof raw.name === 'string' ? raw.name : '',
+    year: typeof raw.year === 'string' ? raw.year : (year?.toString() ?? ''),
+    status: typeof raw.status === 'string' ? raw.status : '',
+    currentRound: parseMongoNumber(raw.currentRound) ?? null,
+    courses: Array.isArray(raw.courses) ? raw.courses.map((c: Record<string, unknown>) => ({
+      courseId: typeof c.courseId === 'string' ? c.courseId : '',
+      courseName: typeof c.courseName === 'string' ? c.courseName : '',
+    })) : [],
+    format: typeof raw.format === 'string' ? raw.format : null,
+    date: typeof raw.date === 'string' ? raw.date : null,
+  }
+}
+
+export async function getLeaderboard(tournamentId: string, year?: number): Promise<SlashLeaderboard> {
+  const params = new URLSearchParams({ orgId: '1', tournId: tournamentId, ...(year && { year: year.toString() }) })
+  const res = await fetch(`${BASE_URL}/leaderboard?${params}`, {
+    headers: { 'X-RapidAPI-Key': process.env.SLASH_GOLF_API_KEY ?? '' },
+    cache: 'no-store'
+  })
+  if (!res.ok) throw new Error('Failed to fetch leaderboard')
+  const raw = await res.json()
+  const rows = Array.isArray(raw.leaderboardRows) ? raw.leaderboardRows : []
+  return {
+    tournId: typeof raw.tournId === 'string' ? raw.tournId : '',
+    year: typeof raw.year === 'string' ? raw.year : (year?.toString() ?? ''),
+    status: typeof raw.status === 'string' ? raw.status : '',
+    roundId: parseMongoNumber(raw.roundId) ?? 0,
+    roundStatus: typeof raw.roundStatus === 'string' ? raw.roundStatus : '',
+    timestamp: typeof raw.timestamp === 'string' ? raw.timestamp : '',
+    leaderboardRows: rows.map((row: Record<string, unknown>) => ({
+      playerId: typeof row.playerId === 'string' ? row.playerId : '',
+      lastName: typeof row.lastName === 'string' ? row.lastName : '',
+      firstName: typeof row.firstName === 'string' ? row.firstName : '',
+      isAmateur: typeof row.isAmateur === 'boolean' ? row.isAmateur : false,
+      status: normalizeSlashStatus(row.status),
+      currentRound: parseMongoNumber(row.currentRound) ?? 1,
+      total: typeof row.total === 'string' ? row.total : (typeof row.total === 'object' ? row.total : '0'),
+      currentRoundScore: typeof row.currentRoundScore === 'string' ? row.currentRoundScore : (typeof row.currentRoundScore === 'object' ? row.currentRoundScore : '0'),
+      position: typeof row.position === 'string' ? row.position : null,
+      totalStrokesFromCompletedRounds: typeof row.totalStrokesFromCompletedRounds === 'string' ? row.totalStrokesFromCompletedRounds : null,
+      rounds: Array.isArray(row.rounds) ? row.rounds : [],
+      thru: typeof row.thru === 'string' ? row.thru : null,
+      startingHole: parseMongoNumber(row.startingHole),
+      currentHole: parseMongoNumber(row.currentHole),
+      courseId: typeof row.courseId === 'string' ? row.courseId : null,
+      teeTime: typeof row.teeTime === 'string' ? row.teeTime : null,
+      teeTimeTimestamp: typeof row.teeTimeTimestamp === 'string' ? row.teeTimeTimestamp : null,
+    })),
+  }
+}
+```
+
+Add `normalizeSlashStatus` to the helper section of `client.ts` (after the existing `normalizeGolferStatus`):
+
+```ts
+function normalizeSlashStatus(value: unknown): SlashGolferStatus {
+  if (typeof value !== 'string') return 'active'
+  const s = value.trim().toLowerCase()
+  if (s === 'withdrawn' || s === 'wd') return 'withdrawn'
+  if (s === 'cut' || s === 'cu') return 'cut'
+  if (s === 'dq') return 'dq'
+  if (s === 'complete' || s === 'finished' || s === 'f') return 'complete'
+  return 'active'
+}
+```
+
+Add the import for `SlashTournamentMeta` and other new types at the top of `client.ts`:
+
+```ts
+import type { Tournament, GolferScore, GolferScoreRound, SlashTournamentMeta, SlashLeaderboard, SlashGolferStatus } from './types'
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run src/lib/__tests__/slash-golf-client.test.ts 2>&1 | tail -20
+```
+
+Expected: PASS for the two new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/slash-golf/client.ts src/lib/__tests__/slash-golf-client.test.ts
+git commit -m "OPS-52: add getTournamentMeta and getLeaderboard endpoint functions
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 4: Add `getScorecard` and `getStats` to `client.ts`
+
+**Files:**
+- Modify: `src/lib/slash-golf/client.ts`
+
+- [ ] **Step 1: Write the failing test for `getScorecard`**
+
+Add to `src/lib/__tests__/slash-golf-client.test.ts`:
+
+```ts
+it('getScorecard returns per-hole scorecard for a golfer', async () => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue({
+      tournId: '014',
+      playerId: '22405',
+      year: '2026',
+      status: 'active',
+      currentRound: 2,
+      holes: [
+        { holeId: 1, par: 4, strokes: 4, scoreToPar: 0 },
+        { holeId: 2, par: 5, strokes: 4, scoreToPar: -1 },
+      ],
+    }),
+  }))
+
+  const scorecard = await getScorecard('014', '22405', 2026)
+  expect(scorecard.tournId).toBe('014')
+  expect(scorecard.playerId).toBe('22405')
+  expect(scorecard.holes).toHaveLength(2)
+  expect(scorecard.holes[0]).toMatchObject({ holeId: 1, par: 4, scoreToPar: 0 })
+  expect(scorecard.holes[1]).toMatchObject({ holeId: 2, par: 5, scoreToPar: -1 })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run src/lib/__tests__/slash-golf-client.test.ts 2>&1 | grep -E "(FAIL|getScorecard)"
+```
+
+Expected: FAIL — `getScorecard is not defined`.
+
+- [ ] **Step 3: Add `getScorecard` to client.ts**
+
+Add after the existing `getTournamentMeta` function:
+
+```ts
+export async function getScorecard(tournamentId: string, golferId: string, year?: number): Promise<SlashScorecard> {
+  const params = new URLSearchParams({ orgId: '1', tournId: tournamentId, playerId: golferId, ...(year && { year: year.toString() }) })
+  const res = await fetch(`${BASE_URL}/scorecard?${params}`, {
+    headers: { 'X-RapidAPI-Key': process.env.SLASH_GOLF_API_KEY ?? '' },
+    cache: 'no-store'
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    console.error('[slash-golf] scorecard fetch failed', { status: res.status, golferId, body })
+    throw new Error('Failed to fetch scorecard')
+  }
+  const raw = await res.json()
+  const holes = Array.isArray(raw.holes) ? raw.holes.map((h: Record<string, unknown>) => ({
+    holeId: parseMongoNumber(h.holeId) ?? 0,
+    par: parseMongoNumber(h.par) ?? 0,
+    strokes: parseMongoNumber(h.strokes) ?? 0,
+    scoreToPar: parseMongoNumber(h.scoreToPar) ?? 0,
+  })).filter((h: SlashHole) => h.holeId > 0) : []
+
+  return {
+    tournId: typeof raw.tournId === 'string' ? raw.tournId : tournamentId,
+    playerId: typeof raw.playerId === 'string' ? raw.playerId : golferId,
+    year: typeof raw.year === 'string' ? raw.year : (year?.toString() ?? ''),
+    status: normalizeSlashStatus(raw.status),
+    currentRound: parseMongoNumber(raw.currentRound) ?? 1,
+    holes,
+  }
+}
+```
+
+- [ ] **Step 4: Write a failing test for `getStats`**
+
+Add to `src/lib/__tests__/slash-golf-client.test.ts`:
+
+```ts
+it('getStats returns player ranking stats', async () => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue({
+      tournId: '014',
+      playerId: '22405',
+      worldRank: 12,
+      projectedOWGR: 8.5,
+    }),
+  }))
+
+  const stats = await getStats('014', '22405', 2026)
+  expect(stats.playerId).toBe('22405')
+  expect(stats.worldRank).toBe(12)
+})
+```
+
+- [ ] **Step 5: Run test to verify it fails**
+
+```bash
+npx vitest run src/lib/__tests__/slash-golf-client.test.ts 2>&1 | grep -E "(FAIL|getStats)"
+```
+
+Expected: FAIL — `getStats is not defined`.
+
+- [ ] **Step 6: Add `getStats` to client.ts**
+
+```ts
+export async function getStats(tournamentId: string, golferId: string, year?: number): Promise<SlashStats> {
+  const params = new URLSearchParams({ orgId: '1', tournId: tournamentId, playerId: golferId, ...(year && { year: year.toString() }) })
+  const res = await fetch(`${BASE_URL}/stats?${params}`, {
+    headers: { 'X-RapidAPI-Key': process.env.SLASH_GOLF_API_KEY ?? '' },
+    cache: 'no-store'
+  })
+  if (!res.ok) throw new Error('Failed to fetch stats')
+  const raw = await res.json()
+  return {
+    tournId: typeof raw.tournId === 'string' ? raw.tournId : tournamentId,
+    playerId: typeof raw.playerId === 'string' ? raw.playerId : golferId,
+    worldRank: typeof raw.worldRank === 'number' ? raw.worldRank : null,
+    projectedOWGR: typeof raw.projectedOWGR === 'number' ? raw.projectedOWGR : null,
+  }
+}
+```
+
+Update the import line at the top of `client.ts` to include the new types:
+
+```ts
+import type { Tournament, GolferScore, GolferScoreRound, SlashTournamentMeta, SlashLeaderboard, SlashGolferStatus, SlashScorecard, SlashHole, SlashStats } from './types'
+```
+
+- [ ] **Step 7: Run all slash-golf tests to verify they pass**
+
+```bash
+npx vitest run src/lib/__tests__/slash-golf-client.test.ts 2>&1 | tail -10
+```
+
+Expected: All PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/slash-golf/client.ts src/lib/__tests__/slash-golf-client.test.ts
+git commit -m "OPS-52: add getScorecard and getStats endpoint functions
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 5: Add `upsertTournamentHoles` to `scoring-queries.ts`
+
+**Files:**
+- Modify: `src/lib/scoring-queries.ts`
+
+- [ ] **Step 1: Write a failing test for `upsertTournamentHoles`**
+
+Add to `src/lib/__tests__/scoring-queries.test.ts`:
+
+```ts
+it('upsertTournamentHoles persists hole records', async () => {
+  const mockSupabase = { ... }
+  vi.mocked(supabaseFrom).mockReturnValue(mockSupabase as never)
+  mockSupabase.from.mockReturnValue({
+    upsert: vi.fn().mockReturnValue({ error: null }),
+  } as never)
+
+  const holes: TournamentHole[] = [
+    { golfer_id: 'g1', tournament_id: 't1', round_id: 1, hole_id: 1, strokes: 4, par: 4, score_to_par: 0 },
+    { golfer_id: 'g1', tournament_id: 't1', round_id: 1, hole_id: 2, strokes: 5, par: 4, score_to_par: 1 },
+  ]
+  const result = await upsertTournamentHoles(mockSupabase as never, holes)
+  expect(result.error).toBeNull()
+})
+```
+
+Note: You may need to create a mock `TournamentHole` type import or define it inline for the test.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run src/lib/__tests__/scoring-queries.test.ts 2>&1 | grep -E "(FAIL|upsertTournamentHoles)"
+```
+
+Expected: FAIL — `upsertTournamentHoles is not defined`.
+
+- [ ] **Step 3: Add `TournamentHole` type to `src/lib/scoring-queries.ts`** (at top of file, after imports)
+
+```ts
+export interface TournamentHole {
+  golfer_id: string
+  tournament_id: string
+  round_id: number
+  hole_id: number
+  strokes: number
+  par: number
+  score_to_par: number
+  updated_at?: string
+}
+```
+
+- [ ] **Step 4: Add `upsertTournamentHoles` function to `src/lib/scoring-queries.ts`**
+
+Add after `getTournamentScoreRounds`:
+
+```ts
+export async function upsertTournamentHoles(
+  supabase: SupabaseClient,
+  holes: TournamentHole[]
+): Promise<{ error: string | null }> {
+  if (holes.length === 0) return { error: null }
+  const records = holes.map(h => ({
+    golfer_id: h.golfer_id,
+    tournament_id: h.tournament_id,
+    round_id: h.round_id,
+    hole_id: h.hole_id,
+    strokes: h.strokes,
+    par: h.par,
+    score_to_par: h.score_to_par,
+    updated_at: h.updated_at ?? new Date().toISOString(),
+  }))
+  const { error } = await supabase
+    .from('tournament_holes')
+    .upsert(records, { onConflict: 'golfer_id,tournament_id,round_id,hole_id' })
+  if (error) return { error: error.message }
+  return { error: null }
+}
+```
+
+Note: The actual `tournament_holes` table will be created by OPS-50 implementation. This function signature is defined now so it is available when OPS-52 implementation begins using it. The function will error at runtime until the table exists (expected behavior).
+
+- [ ] **Step 5: Run TypeScript check**
+
+```bash
+npx tsc --noEmit src/lib/scoring-queries.ts
+```
+
+Expected: No errors (assuming `tournament_holes` table is referenced by name only — no runtime check).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/scoring-queries.ts src/lib/__tests__/scoring-queries.test.ts
+git commit -m "OPS-52: add TournamentHole type and upsertTournamentHoles to scoring-queries
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 6: Write Call Strategy Document
+
+**Files:**
+- Create: `docs/superpowers/specs/ops-52-call-strategy.md`
+
+- [ ] **Step 1: Create the strategy document**
+
+```bash
+cat > docs/superpowers/specs/ops-52-call-strategy.md << 'STRATDOC'
+# OPS-52 Call Strategy — Slash Golf Multi-Endpoint Integration
+
+## Endpoint Overview
+
+| Endpoint | Function | When to Call | Data It Provides |
+|----------|----------|--------------|-----------------|
+| `GET /tournament` | `getTournamentMeta()` | On pool open; on demand | Field list, course info, tournament status |
+| `GET /leaderboard` | `getLeaderboard()` | Every refresh cycle (cron + on-demand) | Round status, player status, refresh targeting |
+| `GET /scorecard` | `getScorecard()` | Selective (see below) | Per-hole strokes for one golfer |
+| `GET /stats` | `getStats()` | Not in MVP scope | World rank, OWGR projections |
+
+## Refresh Targeting via Leaderboard
+
+The `leaderboard.roundStatus` field drives the scorecard fetch strategy:
+
+| `roundStatus` | Meaning | Action |
+|---------------|---------|--------|
+| `'Pre'` | Round not started | Skip scorecard fetches |
+| `'In Progress'` | Live round | Only fetch scorecard for golfers with `thru < 18` |
+| `'Round Complete'` | Round just finished | Fetch scorecard for all rostered golfers to lock hole data |
+| `'Tournament Complete'` | Tournament over | Fetch scorecards for any golfers missing hole data |
+
+## Selective Scorecard Fetch Logic
+
+### ScorecardFetchPlan
+
+```ts
+interface ScorecardFetchPlan {
+  tournamentId: string
+  year: number
+  fetchScorecard: Array<{
+    golferId: string
+    reason: 'round_complete_backfill' | 'in_progress_refresh' | 'status_change'
+  }>
+  skipScorecard: Array<{
+    golferId: string
+    reason: string
+  }>
+}
+```
+
+### Decision Rules (implement in scoring-refresh.ts)
+
+```
+GIVEN leaderboard data for a tournament + existing hole counts per golfer:
+
+FOR each golfer in leaderboardRows:
+  1. If roundStatus === 'Pre':
+     - Skip scorecard. No round has started.
+
+  2. If roundStatus === 'Round Complete' AND golfer has fewer than 18 holes stored:
+     - Fetch scorecard (reason: 'round_complete_backfill')
+
+  3. If roundStatus === 'In Progress':
+     - If golfer.thru < 18 AND golfer.status === 'active':
+       - Fetch scorecard (reason: 'in_progress_refresh')
+     - Else skip.
+
+  4. If golfer.status just changed (active -> cut/wd/dq):
+     - Fetch scorecard once to capture final state (reason: 'status_change')
+     - After fetch, mark golfer inactive for subsequent refreshes.
+
+  5. If golfer has 0 holes stored for a completed round:
+     - Fetch scorecard (reason: 'round_complete_backfill')
+
+  6. Otherwise skip.
+```
+
+## Rate Limiting
+
+RapidAPI Slash Golf tier limits apply. Default tier: ~100 calls/minute.
+
+**Budget per refresh cycle (assumes 156 golfers, 4 rounds):**
+
+| Operation | Calls | Budget |
+|-----------|-------|--------|
+| Tournament meta | 1 | Fixed |
+| Leaderboard | 1 | Fixed |
+| Scorecard (backfill all rostered after round complete) | 156 | 1.6s at 100/min |
+| Scorecard (in-progress only for active golfers with thru < 18) | ~50 | 0.5s at 100/min |
+| Stats | 0 (out of MVP scope) | — |
+
+**Rate limit strategy:** Call `getScorecard` sequentially (not parallel) to stay within RapidAPI limits. Add a 600ms delay between scorecard calls. Alternatively, use a concurrency cap of 3.
+
+```ts
+async function fetchScorecardsWithRateLimit(
+  fetches: Array<() => Promise<SlashScorecard>>,
+  maxConcurrent = 3,
+  delayMs = 600
+): Promise<SlashScorecard[]> {
+  const results: SlashScorecard[] = []
+  for (let i = 0; i < fetches.length; i += maxConcurrent) {
+    const batch = fetches.slice(i, i + maxConcurrent)
+    const batchResults = await Promise.all(batch.map(f => f()))
+    results.push(...batchResults)
+    if (i + maxConcurrent < fetches.length) {
+      await new Promise(resolve => setTimeout(resolve, delayMs))
+    }
+  }
+  return results
+}
+```
+
+## Error Handling Per Endpoint
+
+### Tournament Meta
+- 404: Tournament not published → throw `'Tournament field has not been published yet.'`
+- 429: Rate limited → exponential backoff, max 3 retries
+- 5xx: Server error → fail open with warning (tournament metadata is non-critical)
+
+### Leaderboard
+- Empty `leaderboardRows`: Log warning, return empty array. Do not throw.
+- 429: Rate limited → exponential backoff, max 3 retries
+- Network error → throw so cron can retry on next cycle
+
+### Scorecard
+- 404 for individual golfer → log and skip (golfer may have withdrawn before any data)
+- 429: Rate limited → wait and retry once; if still limited, skip
+- Per-golfer errors must not fail the entire refresh cycle
+
+### Stats
+- Not called in MVP. Errors are logged but non-fatal.
+
+## Quota Tracking
+
+Track API calls per refresh to stay within daily/monthly RapidAPI quotas.
+
+```ts
+let apiCallsThisCycle = 0
+
+async function refreshWithQuotaTracking(pool: RefreshablePool) {
+  // leaderboard call
+  const board = await getLeaderboard(pool.tournamentId, pool.year)
+  apiCallsThisCycle++
+
+  // scorecard calls (rate-limited)
+  for (const fetch of scorecardFetches) {
+    if (apiCallsThisCycle >= QUOTA_LIMIT) {
+      console.warn('[slash-golf] quota limit reached, skipping remaining scorecards')
+      break
+    }
+    await fetch()
+    apiCallsThisCycle++
+  }
+}
+```
+
+## Out-of-Scope Details
+
+- Tournament hole data storage: handled by `upsertTournamentHoles` (OPS-50)
+- Cron scheduling/frequency: handled by OPS-29
+- Real-time scorecard updates during live play: future work
+
+## Fixture Capture
+
+Capture real payloads for CI reproducibility:
+
+```
+fixtures/slash-golf/
+  tournament-{tournamentId}.json    # from /tournament endpoint
+  leaderboard-{tournamentId}.json  # from /leaderboard endpoint
+  scorecard-{tournamentId}-{golferId}.json  # from /scorecard endpoint
+  stats-{tournamentId}-{golferId}.json       # from /stats endpoint
+```
+
+Fixture files should include a JSON comment header:
+```json
+{
+  // fixture: slash-golf scorecard
+  // tournamentId: 014
+  // golferId: 22405
+  // captured: 2026-04-10
+  // note: "status field uses 'complete' not 'finished'"
+  ...
+}
+```
+STRATDOC
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/ops-52-call-strategy.md
+git commit -m "OPS-52: add call strategy documentation for Slash Golf multi-endpoint integration
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 7: Capture Fixture Payloads
+
+**Files:**
+- Create: `fixtures/slash-golf/` (directory)
+
+- [ ] **Step 1: Create fixture directory and stub files**
+
+Note: Real fixtures require live API calls. Create stub files that document the expected shape:
+
+```bash
+mkdir -p fixtures/slash-golf
+cat > fixtures/slash-golf/tournament-STUB.json << 'EOF'
+{
+  // fixture: Slash Golf /tournament response
+  // tournamentId: <fill in from live API>
+  // captured: <date>
+  // note: Capture real response from GET /tournament?orgId=1&tournId=<id>
+  "orgId": "1",
+  "year": "2026",
+  "tournId": "014",
+  "name": "The Masters",
+  "status": "In Progress",
+  "currentRound": 2,
+  "courses": [
+    { "courseId": "014", "courseName": "Augusta National Golf Club" }
+  ],
+  "format": "stroke",
+  "date": "2026-04-10"
+}
+EOF
+```
+
+Create similar stub files for `leaderboard-STUB.json`, `scorecard-STUB.json`, `stats-STUB.json`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add fixtures/slash-golf/
+git commit -m "OPS-52: add fixture stub files for Slash Golf endpoints
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Spec Coverage Checklist
+
+| Spec Requirement | Task |
+|-------------------|------|
+| 4 typed endpoint functions (getTournamentMeta, getLeaderboard, getScorecard, getStats) | Tasks 3, 4 |
+| Status normalization handles complete/dq/wd + existing | Tasks 3, 4 |
+| GolferStatus extended to dq \| complete | Task 2 |
+| upsertTournamentHoles function in scoring-queries | Task 5 |
+| Real fixture capture plan | Task 7 |
+| Call strategy doc | Task 6 |
+| No leaderboard aggregates as sole source of truth | Architecture decision documented in call strategy doc |
+
+---
+
+## Verification Commands
+
+```bash
+# TypeScript check
+npx tsc --noEmit src/lib/slash-golf/types.ts src/lib/slash-golf/client.ts src/lib/scoring-queries.ts
+
+# All tests
+npx vitest run src/lib/__tests__/slash-golf-client.test.ts src/lib/__tests__/scoring-queries.test.ts
+
+# ESLint
+npx eslint src/lib/slash-golf/ --max-warnings 0
+```

--- a/docs/superpowers/plans/2026-04-27-ops-57-fix-score-trace-build.md
+++ b/docs/superpowers/plans/2026-04-27-ops-57-fix-score-trace-build.md
@@ -1,0 +1,113 @@
+# OPS-57: Fix build failure in score-trace page — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix TypeScript type error on line 175 of score-trace page by adding null guards to `ScoreDisplay` call sites.
+
+**Architecture:** Null-coalescing (`?? 0`) on `entry.totalScore` and `row.roundScore` at the two `ScoreDisplay` call sites. No changes to shared `ScoreDisplay` component or to type definitions.
+
+**Tech Stack:** TypeScript, Next.js App Router, React
+
+---
+
+## Task 1: Add null guard on line 175
+
+**Files:**
+- Modify: `src/app/(app)/commissioner/pools/[poolId]/audit/score-trace/page.tsx:175`
+
+- [ ] **Step 1: Verify current line 175 content**
+
+Run: `sed -n '175p' src/app/\(app\)/commissioner/pools/\[poolId\]/audit/score-trace/page.tsx`
+
+Expected output:
+```
+                      Leaderboard score <span className="font-semibold text-gray-900"><ScoreDisplay score={entry.totalScore} /></span>
+```
+
+- [ ] **Step 2: Add null guard**
+
+```typescript
+                      Leaderboard score <span className="font-semibold text-gray-900"><ScoreDisplay score={entry.totalScore ?? 0} /></span>
+```
+
+- [ ] **Step 3: Verify change**
+
+Run: `sed -n '175p' src/app/\(app\)/commissioner/pools/\[poolId\]/audit/score-trace/page.tsx`
+
+Expected output:
+```
+                      Leaderboard score <span className="font-semibold text-gray-900"><ScoreDisplay score={entry.totalScore ?? 0} /></span>
+```
+
+---
+
+## Task 2: Add null guard on lines 209-212
+
+**Files:**
+- Modify: `src/app/(app)/commissioner/pools/[poolId]/audit/score-trace/page.tsx:209-212`
+
+- [ ] **Step 1: Verify current lines 209-214**
+
+Run: `sed -n '209,214p' src/app/\(app\)/commissioner/pools/\[poolId\]/audit/score-trace/page.tsx`
+
+Expected output:
+```
+                                {row.roundScore === null ? (
+                                  <span className="text-gray-400">-</span>
+                                ) : (
+                                  <ScoreDisplay score={row.roundScore} />
+                                )}
+```
+
+- [ ] **Step 2: Add null guard**
+
+Change:
+```
+                                {row.roundScore === null ? (
+                                  <span className="text-gray-400">-</span>
+                                ) : (
+                                  <ScoreDisplay score={row.roundScore} />
+                                )}
+```
+To:
+```
+                                {row.roundScore === null ? (
+                                  <span className="text-gray-400">-</span>
+                                ) : (
+                                  <ScoreDisplay score={row.roundScore ?? 0} />
+                                )}
+```
+
+- [ ] **Step 3: Verify change**
+
+Run: `sed -n '209,214p' src/app/\(app\)/commissioner/pools/\[poolId\]/audit/score-trace/page.tsx`
+
+Expected output:
+```
+                                {row.roundScore === null ? (
+                                  <span className="text-gray-400">-</span>
+                                ) : (
+                                  <ScoreDisplay score={row.roundScore ?? 0} />
+                                )}
+```
+
+---
+
+## Task 3: Verify build passes
+
+- [ ] **Step 1: Run production build**
+
+Run: `npm run build 2>&1`
+Expected: Build completes without type errors. No `score-trace/page.tsx` errors.
+
+---
+
+## Task 4: Commit changes
+
+- [ ] **Step 1: Stage and commit**
+
+```bash
+git add src/app/\(app\)/commissioner/pools/\[poolId\]/audit/score-trace/page.tsx
+git commit -m "OPS-57: null guard ScoreDisplay call sites in score-trace page"
+```
+Co-Authored-By: Paperclip <noreply@paperclip.ing>

--- a/docs/superpowers/specs/2026-04-25-ops-49-mvp-rules-freeze-design.md
+++ b/docs/superpowers/specs/2026-04-25-ops-49-mvp-rules-freeze-design.md
@@ -89,9 +89,18 @@ Before proceeding, I need to clarify scope:
 
 ## Acceptance Criteria
 
-- [ ] Master freeze doc exists at `docs/superpowers/specs/YYYY-MM-DD-ops-49-mvp-rules-freeze.md`
-- [ ] All 8 rule domains covered with explicit file/function references
-- [ ] Edge cases documented (no "TBD" or "unknown")
-- [ ] `isTied` behavior for legacy ranking addressed explicitly
-- [ ] CLAUDE.md "Critical Rules" section updated with checklist + link to full doc
-- [ ] Self-review passed: no placeholders, no internal contradictions
+- [x] Master freeze doc exists at `docs/rules-spec.md` (note: per issue deliverable, placed at `docs/rules-spec.md` not `docs/superpowers/specs/`)
+- [x] All 8 rule domains covered with explicit file/function references
+- [x] Edge cases documented (no "TBD" or "unknown") — see Section 9 Edge Case Matrix
+- [x] `isTied` behavior for legacy ranking addressed explicitly (rankEntriesLegacy documented as deprecated)
+- [x] Open questions documented (Section 11) with clarification needs
+- [ ] CLAUDE.md "Critical Rules" section updated with checklist + link to full doc (deferred to implementation phase)
+- [x] Self-review passed: no placeholders, no internal contradictions
+
+## Design Decisions Resolved
+
+1. **Audience depth:** Both. Rules spec is layered: summary-style in Sections 1–8, detailed reference in Section 9 (matrix). Future engineers can use Section 9 as implementation reference.
+
+2. **What constitutes "frozen":** Snapshot of current behavior with known gaps documented in Section 11 (Open Questions). `rankEntriesLegacy` is documented as deprecated but still deployed.
+
+3. **Legacy code treatment:** `rankEntriesLegacy` (`scoring.ts:84`) is documented as non-canonical. It lacks `isTied` in its return type and does not properly handle ties. `rankEntries` (domain) is the canonical implementation.

--- a/docs/superpowers/specs/2026-04-25-ops-49-mvp-rules-freeze-design.md
+++ b/docs/superpowers/specs/2026-04-25-ops-49-mvp-rules-freeze-design.md
@@ -1,0 +1,97 @@
+# OPS-49: Freeze MVP Rules and Edge Cases — Design Spec
+
+## Problem Statement
+
+The Fantasy Golf Pool MVP has accumulated business rules across multiple files with no single authoritative source. Some rules are documented in code comments, some in test names, some only in the implementation. This makes it difficult to:
+- Onboard new engineers
+- Verify edge case behavior
+- Identify gaps or inconsistencies
+- Make changes without unintended side effects
+
+The goal of OPS-49 is to **document what is implemented** (canonical behavior) as of this freeze, not to prescribe what should be built.
+
+---
+
+## Rule Domains to Freeze
+
+| Domain | Key Files | Summary |
+|--------|-----------|---------|
+| **Scoring** | `src/lib/scoring.ts`, `src/lib/scoring/domain.ts` | Best-ball (lowest score per round), birdie tiebreaker, active-only golfers, round completion gating |
+| **Pool Lifecycle** | `src/lib/pool.ts` | Status transitions: open→live→complete→archived (no other paths), canReopenPool guards against expired deadlines |
+| **Locking/Deadlines** | `src/lib/picks.ts` | Timezone-aware lock instant calculation via iterative offset resolution, isPoolLocked, shouldAutoLock, isCommissionerPoolLocked |
+| **Entry/Pick Validation** | `src/lib/picks.ts` | No duplicate golfers, exact picksPerEntry count required, locked pool rejects all mutations |
+| **Data Freshness** | `src/app/api/leaderboard/[poolId]/route.ts`, `CLAUDE.md` | 15-minute staleness threshold, server-triggered upstream refresh, client re-fetches on mount/broadcast/reconnect/visibility |
+| **Archive/No-Retroactivity** | `src/lib/scoring-queries.ts`, test at `scoring-queries.test.ts:109` | Archive rounds before writing current score; archive records must NOT include round_status (Board-authorized rule) |
+| **Audit Trail** | `src/lib/audit.ts` | Score diff tracking (round_id, total_score, position, status, birdies), refresh audit events |
+| **API/Cron** | `docs/runbooks/fantasy-golf-ops.md` | CRON_SECRET bearer auth, isUpdating mutex prevents concurrent refreshes, fan-out refreshes all same-tournament pools |
+
+---
+
+## Document Structure
+
+### Option: Hybrid (Recommended)
+
+Create a domain-organized freeze document with a CLAUDE.md summary.
+
+**`docs/superpowers/specs/YYYY-MM-DD-ops-49-mvp-rules-freeze.md`** — Master freeze document organized by domain. Each rule states:
+- What it does (one sentence)
+- What file/function implements it
+- What test or check covers it
+- Any known edge cases or ambiguities
+
+**CLAUDE.md "Critical Rules" section update** — Already exists. Will be enhanced to:
+1. State the 5-10 non-negotiable rules as a checklist
+2. Link to the full freeze doc for implementation details
+
+### Domain Sub-Documents (if scope warrants)
+
+If the master doc grows too large, split into:
+- `docs/rules/scoring-rules.md`
+- `docs/rules/pool-lifecycle.md`
+- `docs/rules/locking-deadline.md`
+- `docs/rules/entry-rules.md`
+- `docs/rules/data-freshness.md`
+- `docs/rules/archive-rules.md`
+
+For now, keep it as a single document with domain sections. Split only if needed.
+
+---
+
+## Approach Comparison
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **A: CLAUDE.md only** | Single authoritative location | Mixes concerns; easily bloats |
+| **B: New freeze doc only** | Clean slate, comprehensive | Discovery risk; may drift |
+| **C: Hybrid (recommended)** | Detail + summary, clear ownership | Two docs to maintain |
+
+**Recommendation: Approach C (Hybrid)**
+
+---
+
+## Clarifying Questions for Product Planner
+
+Before proceeding, I need to clarify scope:
+
+1. **Legacy code treatment**: `rankEntriesLegacy` in `scoring.ts:84` doesn't handle `isTied` correctly (returns untyped rank). Should this be documented as canonical (what's deployed) or flagged as known deviation from the modern `rankEntries`?
+
+2. **Audience depth**: Is the freeze doc intended for:
+   - **Commissioners** (what rules exist, high-level)
+   - **Future engineers** (implementation details, edge cases)
+   - **Both** (layered: summary + deep-dive)?
+
+3. **What constitutes "frozen"**: Should the freeze doc be:
+   - **A snapshot** of current behavior (observable from tests/code)
+   - **A declaration** with explicit exclusions (flag places that are known wrong)
+   - **A living document** that updates as rules change?
+
+---
+
+## Acceptance Criteria
+
+- [ ] Master freeze doc exists at `docs/superpowers/specs/YYYY-MM-DD-ops-49-mvp-rules-freeze.md`
+- [ ] All 8 rule domains covered with explicit file/function references
+- [ ] Edge cases documented (no "TBD" or "unknown")
+- [ ] `isTied` behavior for legacy ranking addressed explicitly
+- [ ] CLAUDE.md "Critical Rules" section updated with checklist + link to full doc
+- [ ] Self-review passed: no placeholders, no internal contradictions

--- a/docs/superpowers/specs/2026-04-25-ops-50-scoring-engine-rebuild-design.md
+++ b/docs/superpowers/specs/2026-04-25-ops-50-scoring-engine-rebuild-design.md
@@ -37,7 +37,9 @@ The difference is significant when golfers have different round profiles (e.g., 
 
 1. **`computeEntryScore()` in `domain.ts` is already correct.** The algorithm iterates over `golferRoundScores`, groups by `roundId`, takes the minimum `scoreToPar` per round, sums those minima, and counts completed rounds. The bug is that the input data (`buildGolferRoundScoresMap`) produces wrong-shaped data.
 
-2. **`tournament_holes` table does not exist yet.** The hole-by-hole design from 2026-04-11 was specced but never implemented. OPS-50 must create this table and populate it correctly.
+2. **`PlayerHoleScore` interface in `domain.ts` currently lacks `holeId`.** The hole-level algorithm requires `holeId` to uniquely identify each hole. The interface must be updated to include `holeId: number` before the hole-level algorithm can work correctly.
+
+3. **`tournament_holes` table does not exist yet.** The hole-by-hole design from 2026-04-11 was specced but never implemented. OPS-50 must create this table and populate it correctly.
 
 3. **The existing `tournament_score_rounds` table has round-level aggregates**, not hole-level data. `score_to_par` in that table is the golfer's total score-to-par for completed rounds, not per-hole scores.
 
@@ -120,6 +122,7 @@ function buildGolferRoundScoresMap(
   for (const [golferId, holes] of holesByGolfer) {
     const rounds: PlayerHoleScore[] = holes.map(hole => ({
       roundId: hole.round_id,
+      holeId: hole.hole_id,    // ADD THIS: enables hole-level best ball
       scoreToPar: hole.score_to_par,
       status: golferStatuses.get(golferId) ?? 'active',
       isComplete: true,  // only completed holes are stored
@@ -230,6 +233,18 @@ With hole-level data:
 - A golfer who is cut/WD is filtered from `activeGolferIds` for subsequent rounds but their completed holes still exist in `golferRoundScores`
 
 ## Data Model Changes
+
+### Update `PlayerHoleScore` in `src/lib/scoring/domain.ts`
+
+```ts
+export interface PlayerHoleScore {
+  roundId: number
+  holeId: number         // ADD THIS: 1-18 — enables hole-level indexing
+  scoreToPar: number | null
+  status: GolferStatus
+  isComplete: boolean
+}
+```
 
 ### New type: `TournamentHole`
 

--- a/docs/superpowers/specs/2026-04-25-ops-50-scoring-engine-rebuild-design.md
+++ b/docs/superpowers/specs/2026-04-25-ops-50-scoring-engine-rebuild-design.md
@@ -1,0 +1,315 @@
+---
+name: OPS-50 Rebuild Scoring Engine for Hole-by-Hole Best Ball
+description: Replace aggregate-score shortcuts with per-hole best ball computation using stored tournament_holes data
+module: scoring
+tags: [scoring, hole-by-hole, best-ball, domain]
+git_refs: []
+problem_type: bug-fix
+date: 2026-04-25
+---
+
+# OPS-50: Rebuild Scoring Engine for Hole-by-Hole Best Ball
+
+## Problem
+
+The current scoring implementation (`src/lib/scoring.ts`) uses aggregate golfer scores from the leaderboard to compute entry scores. This is a shortcut that does not correctly implement best-ball scoring.
+
+**Current behavior:**
+```ts
+// buildGolferRoundScoresMap in scoring.ts
+result.set(golferId, [{
+  roundId: score.round_id ?? 1,
+  scoreToPar: score.total_score,  // <-- BUG: aggregate tournament score
+  status: score.status,
+  isComplete: true,
+}])
+```
+
+This produces a map where each golfer has ONE entry with their entire tournament `total_score` as `scoreToPar`. Then `computeEntryScore` takes `Math.min(...)` of these aggregate values.
+
+**What this computes:** "Give me the golfer with the lowest tournament total and use that as the entry score."
+
+**What best-ball actually is:** "For each hole, give me the lowest score among active golfers in the entry. Sum those minima."
+
+The difference is significant when golfers have different round profiles (e.g., one golfer goes -6 on round 1 but +4 on round 2, while another goes -2 on round 1 and -2 on round 2).
+
+## Key Constraints
+
+1. **`computeEntryScore()` in `domain.ts` is already correct.** The algorithm iterates over `golferRoundScores`, groups by `roundId`, takes the minimum `scoreToPar` per round, sums those minima, and counts completed rounds. The bug is that the input data (`buildGolferRoundScoresMap`) produces wrong-shaped data.
+
+2. **`tournament_holes` table does not exist yet.** The hole-by-hole design from 2026-04-11 was specced but never implemented. OPS-50 must create this table and populate it correctly.
+
+3. **The existing `tournament_score_rounds` table has round-level aggregates**, not hole-level data. `score_to_par` in that table is the golfer's total score-to-par for completed rounds, not per-hole scores.
+
+4. **Birdie counting must also be hole-level.** A birdie is counted when the best-ball score for a hole is below par. The current implementation counts birdies at the round level (one birdie per round if `bestBall < 0`).
+
+5. **Round-gating rule from rules-spec section 2.3:** "A round only counts toward the entry total if **all golfers** in the entry have `isComplete: true` for that round." This must be preserved.
+
+## Solution Overview
+
+### Data Flow
+
+```
+tournament_holes (per-hole strokes)
+    ↓
+buildGolferRoundScoresMap() → GolferRoundScoresMap
+    ↓
+computeEntryScore() → entry total score + birdies + completed holes
+    ↓
+rankEntries() → ranked leaderboard
+```
+
+### 1. Create `tournament_holes` table
+
+```sql
+CREATE TABLE tournament_holes (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  golfer_id TEXT NOT NULL,
+  tournament_id TEXT NOT NULL,
+  round_id INTEGER NOT NULL CHECK (round_id BETWEEN 1 AND 4),
+  hole_id INTEGER NOT NULL CHECK (hole_id BETWEEN 1 AND 18),
+  strokes INTEGER NOT NULL,
+  par INTEGER NOT NULL,
+  score_to_par INTEGER NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(golfer_id, tournament_id, round_id, hole_id)
+);
+
+CREATE INDEX idx_tournament_holes_lookup
+  ON tournament_holes(tournament_id, golfer_id, round_id);
+
+ALTER TABLE tournament_holes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "tournament_holes_service_role_all"
+  ON tournament_holes FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON tournament_holes TO service_role;
+```
+
+### 2. Add hole data sync to `scoring-refresh.ts`
+
+When refreshing scores, fetch `/scorecard` for each golfer with completed rounds and persist verified hole data to `tournament_holes`. This is the same work described in the 2026-04-11 hole-by-hole design spec.
+
+### 3. Fix `buildGolferRoundScoresMap()` to use hole data
+
+**Current (wrong):**
+```ts
+function buildGolferRoundScoresMap(tournamentScores: Map<string, TournamentScore>): GolferRoundScoresMap {
+  const result: GolferRoundScoresMap = new Map()
+  for (const [golferId, score] of tournamentScores) {
+    result.set(golferId, [{
+      roundId: score.round_id ?? 1,
+      scoreToPar: score.total_score,  // aggregate!
+      status: score.status,
+      isComplete: true,
+    }])
+  }
+  return result
+}
+```
+
+**Correct (new):**
+```ts
+function buildGolferRoundScoresMap(
+  holesByGolfer: Map<string, TournamentHole[]>,
+  golferStatuses: Map<string, GolferStatus>
+): GolferRoundScoresMap {
+  const result: GolferRoundScoresMap = new Map()
+
+  for (const [golferId, holes] of holesByGolfer) {
+    const rounds: PlayerHoleScore[] = holes.map(hole => ({
+      roundId: hole.round_id,
+      scoreToPar: hole.score_to_par,
+      status: golferStatuses.get(golferId) ?? 'active',
+      isComplete: true,  // only completed holes are stored
+    }))
+    result.set(golferId, rounds)
+  }
+
+  return result
+}
+```
+
+Each `TournamentHole` becomes one `PlayerHoleScore` entry in the map.
+
+### 4. Update scoring entry points
+
+The functions that currently build `GolferRoundScoresMap` from `TournamentScore` must be updated:
+
+- `rankEntries()` in `scoring.ts`
+- Any other caller of `domainRankEntries()`
+
+These must now accept hole data and statuses separately.
+
+### 5. Rewrite `computeEntryScore()` for hole-level best ball
+
+The current algorithm groups by `roundId` and takes one best-ball per round. For true hole-level best ball, we need to group by `(roundId, holeId)` pairs.
+
+**New algorithm structure:**
+
+```ts
+export function computeEntryScore(
+  golferRoundScores: GolferRoundScoresMap,  // hole-level: each entry is one hole
+  activeGolferIds: string[]
+): EntryScoreAccumulator {
+  // Index holes by (roundId, holeId) -> scores from all golfers
+  const holesIndex = new Map<string, Array<{ golferId: string; scoreToPar: number | null; isComplete: boolean }>>()
+
+  for (const [golferId, rounds] of golferRoundScores) {
+    for (const round of rounds) {
+      const holeKey = `${round.roundId}-${round.holeId}`
+      if (!holesIndex.has(holeKey)) {
+        holesIndex.set(holeKey, [])
+      }
+      holesIndex.get(holeKey)!.push({
+        golferId,
+        scoreToPar: round.scoreToPar,
+        isComplete: round.isComplete,
+      })
+    }
+  }
+
+  // Determine which rounds are complete for all active golfers
+  const roundCompletion = new Map<number, boolean>()
+  for (const [holeKey, entries] of holesIndex) {
+    const roundId = parseInt(holeKey.split('-')[0])
+    const allComplete = entries.every(e => e.isComplete)
+    const current = roundCompletion.get(roundId)
+    roundCompletion.set(roundId, current === undefined ? allComplete : current && allComplete)
+  }
+
+  // Compute best ball per hole, sum only complete rounds
+  let totalScore: number | null = 0
+  let totalBirdies = 0
+  let completedHoles = 0
+
+  const activeSet = new Set(activeGolferIds)
+
+  for (const [holeKey, entries] of holesIndex) {
+    const [roundIdStr, holeIdStr] = holeKey.split('-')
+    const roundId = parseInt(roundIdStr)
+
+    if (!roundCompletion.get(roundId)) continue
+
+    const activeEntries = entries.filter(e => activeSet.has(e.golferId) && e.isComplete)
+    if (activeEntries.length === 0) continue
+
+    const validScores = activeEntries
+      .map(e => e.scoreToPar)
+      .filter((s): s is number => s !== null)
+
+    if (validScores.length === 0) continue
+
+    const bestBall = Math.min(...validScores)
+    totalScore = (totalScore !== null ? totalScore : 0) + bestBall
+    completedHoles++
+
+    if (isBirdie(bestBall)) totalBirdies++
+  }
+
+  return { totalScore, totalBirdies, completedHoles, activeGolferIds }
+}
+```
+
+Key changes:
+- Index by `(roundId, holeId)` instead of just `roundId`
+- Check round completion (all active golfers must have complete hole data)
+- Sum best-ball per hole, not per round
+- Count `completedHoles` as actual holes scored
+
+### 6. Round completion and active golfer filtering
+
+Rules spec section 2.2/2.3:
+- Active golfers (status === 'active') count in best-ball calculation
+- Cut/WD golfers are excluded from subsequent rounds but their completed rounds still count
+- A round only counts if ALL active golfers in the entry have `isComplete: true`
+With hole-level data:
+- `isComplete: true` for a golfer's hole means we have verified hole data
+- A round is complete for an entry when all active golfers have `isComplete: true` for all 18 holes
+- A golfer who is cut/WD is filtered from `activeGolferIds` for subsequent rounds but their completed holes still exist in `golferRoundScores`
+
+## Data Model Changes
+
+### New type: `TournamentHole`
+
+```ts
+export interface TournamentHole {
+  golfer_id: string
+  tournament_id: string
+  round_id: number
+  hole_id: number
+  strokes: number
+  par: number
+  score_to_par: number
+  updated_at?: string
+}
+```
+
+### New query functions in `scoring-queries.ts`
+
+```ts
+export async function getTournamentHolesForGolfers(
+  supabase: SupabaseClient,
+  tournamentId: string,
+  golferIds: string[]
+): Promise<Map<string, TournamentHole[]>>
+
+export async function upsertTournamentHoles(
+  supabase: SupabaseClient,
+  holes: TournamentHole[]
+): Promise<{ error: string | null }>
+```
+
+## Display Considerations
+
+The picks page shows:
+- "Counted in N rounds" → should show "X of Y holes"
+- Birdies shown per entry → should count hole-level birdies
+
+These UI changes are out of scope for OPS-50 (the scoring engine rebuild), but the data changes enable them.
+
+## Out of Scope
+
+- UI changes to display hole-level metrics
+- Scorecard API fetching (part of OPS-28)
+- Cron/pipeline hardening (part of OPS-29)
+- Regression test coverage (part of OPS-30)
+
+## Dependencies
+
+- `tournament_holes` table must exist before scoring can use it
+- Hole data must be populated (via OPS-28 scorecard integration)
+- Rules spec section 2.1/2.3 defines the scoring contract
+
+## Test Scenarios
+
+| Scenario | Input | Expected Output |
+|----------|-------|----------------|
+| Normal round | g1: -3, g2: +1, g3: E, g4: +2 | Entry score = -3 |
+| All same score | g1: -2, g2: -2, g3: -2, g4: -2 | Entry score = -2 |
+| Golfer WD | g1: -3, g2: WD, g3: E, g4: +2 | Entry score = -2 (best of g1,g3,g4) |
+| Cut mid-tournament | g1: -3, cut after R1, g2: -2, g3: E, g4: +2 | R1: -3, R2+: best of g2,g3,g4 |
+| Partial entry | g1: -3, g2: no data, g3: E, g4: +2 | Round with missing golfer is skipped |
+
+## Alternative Approaches
+
+### A) Minimal fix: Keep round-level counting, improve data granularity
+
+Keep `computeEntryScore()` as-is (counting rounds), but fix `buildGolferRoundScoresMap()` to use stored round-level scores instead of tournament totals.
+
+**Problem:** Does not satisfy "sums across scored holes" in acceptance criteria.
+
+### B) Full hole-level rebuild (recommended above)
+
+Rewrite `computeEntryScore()` to iterate over `(roundId, holeId)` pairs and count holes.
+
+**Advantage:** Satisfies acceptance criteria exactly. Algorithm becomes the source of truth for hole-level best ball.
+
+### C) Separate scoring paths
+
+Keep round-level scoring for leaderboard (fast, uses aggregate data) and add hole-level scoring for picks display (uses `tournament_holes`).
+
+**Problem:** Two different scoring algorithms for the same game format creates confusion and potential inconsistency.
+
+**Recommended:** Option B - full hole-level rebuild.

--- a/docs/superpowers/specs/2026-04-26-ops-51-supabase-schema-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-04-26-ops-51-supabase-schema-reconciliation-design.md
@@ -1,0 +1,361 @@
+---
+name: OPS-51 Reconcile Supabase Schema, Migrations, and Generated Types
+description: Establish a single source of truth for the database schema by reconciling schema.sql, applied migrations, and TypeScript types
+module: infrastructure
+tags: [database, supabase, schema, types, migrations]
+git_refs: []
+problem_type: cleanup
+date: 2026-04-26
+---
+
+# OPS-51: Reconcile Supabase Schema, Migrations, and Generated Types
+
+## Problem
+
+The persistence model exists in three places that are not fully synchronized:
+
+1. **`src/lib/db/schema.sql`** — The legacy reference schema (outdated)
+2. **`supabase/migrations/`** — The actual applied migrations (source of truth)
+3. **`src/lib/supabase/types.ts`** — TypeScript type definitions
+
+This drift creates risk during handoff. New developers reading `schema.sql` will get a wrong picture of the data model. TypeScript types may not match runtime reality.
+
+## Scope
+
+Reconcile the canonical data model for:
+- `pools`
+- `pool_members`
+- `entries`
+- `golfers`
+- `tournament_scores`
+- `tournament_score_rounds`
+- `audit_events`
+- `pool_deletions`
+- `golfer_sync_runs`
+
+Work includes:
+- Auditing `schema.sql` against applied migrations to identify all discrepancies
+- Updating `schema.sql` to reflect the actual runtime schema
+- Verifying `types.ts` aligns with the canonical schema
+- Documenting source data vs derived values
+- Clarifying hole-level scoring storage strategy
+
+## What Exists Today
+
+### Migrations (Source of Truth, Chronological)
+
+| Migration | Creates/Modifies |
+|-----------|-----------------|
+| `20260331100000` | Extends `golfers` with metadata cols; creates `golfer_sync_runs` |
+| `20260401090000` | Creates `tournament_roster` table |
+| `20260401100000` | Adds `timezone` to `pools` |
+| `20260401101000` | Enables RLS on public tables |
+| `20260401110000` | Adds hourly scoring dispatcher cron |
+| `20260401120000` | Drops legacy golfers table |
+| `20260401130000` | Updates scoring dispatcher |
+| `20260401140000` | Grants service role access |
+| `20260401150000` | Adds round snapshot columns |
+| `20260401160000` | Drops `hole_1`–`hole_18` from `tournament_scores` |
+| `20260401170000` | Creates `tournament_score_rounds` |
+| `20260408100000` | Adds pool write access |
+| `20260408110000` | Adds tournament golfers RLS |
+| `20260408183000` | Adds `archived` to pool status; creates `pool_deletions` |
+| `20260409210000` | Public entries read access |
+| `20260410103000` | Grants service role tournament_score_rounds access |
+
+### Current schema.sql (Stale)
+
+`schema.sql` has not been updated since early development. It shows:
+- `golfers` table with only `id`, `name`, `country`
+- `tournament_scores` with `hole_1`–`hole_18` columns (removed)
+- `pools` without `timezone`
+- `pools.status` CHECK without `'archived'`
+- No `pool_deletions` table
+- No `golfer_sync_runs` table
+- No `tournament_score_rounds` table
+
+### Current types.ts (Mostly Correct)
+
+`types.ts` aligns with the actual schema except for one field name discrepancy:
+- `PoolDeletion.status_at_delete` in types.ts matches `pool_deletions.status_at_delete` in migration (correct)
+
+## Canonical Schema (Target State)
+
+### pools
+```sql
+CREATE TABLE pools (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  commissioner_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  name TEXT NOT NULL,
+  tournament_id TEXT NOT NULL,
+  tournament_name TEXT NOT NULL,
+  year INTEGER NOT NULL CHECK (year >= 2000 AND year <= 2100),
+  deadline TIMESTAMPTZ NOT NULL,
+  timezone TEXT NOT NULL DEFAULT 'America/New_York',
+  format TEXT DEFAULT 'best_ball' CHECK (format IN ('best_ball')),
+  picks_per_entry INTEGER DEFAULT 4 CHECK (picks_per_entry >= 1 AND picks_per_entry <= 10),
+  invite_code TEXT UNIQUE NOT NULL,
+  status TEXT DEFAULT 'open' CHECK (status IN ('open', 'live', 'complete', 'archived')),
+  refreshed_at TIMESTAMPTZ,
+  last_refresh_error TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+```
+
+### pool_members
+```sql
+CREATE TABLE pool_members (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  pool_id UUID REFERENCES pools(id) ON DELETE CASCADE NOT NULL,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  role TEXT DEFAULT 'player' CHECK (role IN ('commissioner', 'player')),
+  joined_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(pool_id, user_id)
+);
+```
+
+### entries
+```sql
+CREATE TABLE entries (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  pool_id UUID REFERENCES pools(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  golfer_ids TEXT[] NOT NULL DEFAULT '{}',
+  total_birdies INTEGER DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(pool_id, user_id)
+);
+```
+
+### golfers
+```sql
+CREATE TABLE golfers (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  country TEXT,
+  search_name TEXT,
+  world_rank INTEGER,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  source TEXT NOT NULL DEFAULT 'legacy' CHECK (source IN ('legacy', 'monthly_sync', 'tournament_sync', 'manual_add')),
+  external_player_id TEXT UNIQUE,
+  last_synced_at TIMESTAMPTZ
+);
+```
+
+### tournament_scores (current-state only)
+```sql
+CREATE TABLE tournament_scores (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  golfer_id TEXT REFERENCES golfers(id),
+  tournament_id TEXT NOT NULL,
+  round_id INTEGER,
+  total_score INTEGER,
+  position TEXT,
+  total_birdies INTEGER DEFAULT 0,
+  status TEXT DEFAULT 'active' CHECK (status IN ('active', 'withdrawn', 'cut')),
+  updated_at TIMESTAMPTZ,
+  UNIQUE(golfer_id, tournament_id)
+);
+```
+
+### tournament_score_rounds (per-round archive)
+```sql
+CREATE TABLE tournament_score_rounds (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  golfer_id TEXT NOT NULL,
+  tournament_id TEXT NOT NULL,
+  round_id INTEGER NOT NULL,
+  strokes INTEGER,
+  score_to_par INTEGER,
+  course_id TEXT,
+  course_name TEXT,
+  round_status TEXT,
+  position TEXT,
+  total_score INTEGER,
+  total_strokes_from_completed_rounds INTEGER,
+  current_hole INTEGER,
+  thru INTEGER,
+  starting_hole INTEGER,
+  current_round INTEGER,
+  current_round_score INTEGER,
+  tee_time TEXT,
+  tee_time_timestamp TIMESTAMPTZ,
+  is_amateur BOOLEAN DEFAULT FALSE,
+  status TEXT DEFAULT 'active' CHECK (status IN ('active', 'withdrawn', 'cut')),
+  total_birdies INTEGER DEFAULT 0,
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(golfer_id, tournament_id, round_id)
+);
+```
+
+### pool_deletions
+```sql
+CREATE TABLE pool_deletions (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  pool_id UUID NOT NULL UNIQUE,
+  commissioner_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  deleted_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  status_at_delete TEXT NOT NULL CHECK (status_at_delete IN ('open', 'live', 'complete', 'archived')),
+  snapshot JSONB NOT NULL DEFAULT '{}',
+  deleted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+### golfer_sync_runs
+```sql
+CREATE TABLE golfer_sync_runs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_type TEXT NOT NULL CHECK (run_type IN ('monthly_baseline', 'pre_tournament', 'manual_add')),
+  requested_by UUID,
+  tournament_id TEXT,
+  api_calls_used INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL CHECK (status IN ('success', 'failed', 'blocked')),
+  summary JSONB NOT NULL DEFAULT '{}',
+  error_message TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+### audit_events
+```sql
+CREATE TABLE audit_events (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  pool_id UUID REFERENCES pools(id) ON DELETE CASCADE NOT NULL,
+  user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  action TEXT NOT NULL,
+  details JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+```
+
+### tournament_roster (referenced in migrations)
+```sql
+-- From 20260401090000_add_tournament_roster.sql
+CREATE TABLE tournament_roster (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  tournament_id TEXT NOT NULL,
+  golfer_id TEXT NOT NULL REFERENCES golfers(id),
+  -- ... additional fields per migration
+);
+```
+
+## Discrepancies Found
+
+| Item | schema.sql | Actual (Migrations) | types.ts |
+|------|-----------|---------------------|----------|
+| `pools.timezone` | Missing | Added `20260401100000` | `Pool.timezone: string` ✅ |
+| `pools.status` CHECK | `'open', 'live', 'complete'` | + `'archived'` in `20260408183000` | `PoolStatus = 'open' \| 'live' \| 'complete' \| 'archived'` ✅ |
+| `golfers` columns | `id, name, country` only | Extended in `20260331100000` | `Golfer` interface has all fields ✅ |
+| `tournament_scores.hole_1-18` | Present | Dropped in `20260401160000` | `TournamentScore` has no hole cols ✅ |
+| `tournament_score_rounds` | Missing | Created `20260401170000` | `TournamentScoreRound` interface ✅ |
+| `pool_deletions` | Missing | Created `20260408183000` | `PoolDeletion` interface ✅ |
+| `golfer_sync_runs` | Missing | Created `20260331100000` | `GolferSyncRun` interface ✅ |
+
+## Source Data vs Derived Values
+
+### Source Data (from external APIs)
+
+| Table | Source | Fields |
+|-------|--------|--------|
+| `golfers` | Slash Golf API (via sync) | `name`, `country`, `world_rank`, `external_player_id`, `is_active`, `source`, `last_synced_at` |
+| `tournament_scores` | Slash Golf `/leaderboard` | `round_id`, `total_score`, `position`, `status`, `updated_at` |
+| `tournament_score_rounds` | Slash Golf `/leaderboard.rounds[]` | `round_id`, `strokes`, `score_to_par`, `course_id`, `course_name`, `round_status`, `position`, `total_score`, `total_strokes_from_completed_rounds`, `current_hole`, `thru`, `starting_hole`, `current_round`, `current_round_score`, `tee_time`, `tee_time_timestamp`, `is_amateur`, `status`, `total_birdies` |
+
+### Derived Values (computed in application code)
+
+| Table | Field | Computation |
+|-------|-------|-------------|
+| `entries` | `total_birdies` | Sum of birdies from best-ball scoring algorithm |
+| `pools` | `refreshed_at` | Set by scoring refresh cron |
+| `pools` | `last_refresh_error` | Set by scoring refresh cron on failure |
+
+### Note on Birdies
+
+`total_birdies` in both `tournament_scores` and `tournament_score_rounds` is currently always 0. The Slash Golf API does not provide birdie counts. Birdies are computed at display time via the scoring algorithm.
+
+## Hole-Level Scoring Storage Strategy
+
+The current schema stores round-level data in `tournament_score_rounds`, but **does not** store hole-level data. The `tournament_holes` table described in the hole-by-hole design spec (OPS-50) has not been created.
+
+**Current state:**
+- `tournament_score_rounds` stores per-round aggregates: `strokes`, `score_to_par`
+- No per-hole breakdown exists in the database
+
+**Hole-level storage (if needed per OPS-50):**
+
+```sql
+CREATE TABLE tournament_holes (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  golfer_id TEXT NOT NULL,
+  tournament_id TEXT NOT NULL,
+  round_id INTEGER NOT NULL CHECK (round_id BETWEEN 1 AND 4),
+  hole_id INTEGER NOT NULL CHECK (hole_id BETWEEN 1 AND 18),
+  strokes INTEGER NOT NULL,
+  par INTEGER NOT NULL,
+  score_to_par INTEGER NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(golfer_id, tournament_id, round_id, hole_id)
+);
+```
+
+This table is **not currently in the schema** — it is pending OPS-50 implementation. The hole-level scoring strategy is deferred until OPS-50 is prioritized.
+
+## Migration Cleanup
+
+The `supabase/migrations/` directory should be the authoritative record of schema evolution. No migrations should be deleted or reordered. New developers should understand that:
+
+1. Apply all migrations in filename order to reach current schema
+2. `schema.sql` is for documentation only and may lag migrations
+3. `types.ts` should be manually kept in sync with migrations
+
+## Implementation Tasks
+
+1. **Update `src/lib/db/schema.sql`** to match canonical schema above
+   - Replace entire file content with canonical schema
+   - Remove stale comments and legacy definitions
+
+2. **Audit `src/lib/supabase/types.ts`**
+   - Verify all types match canonical schema columns exactly
+   - Add JSDoc comments linking types to tables
+   - Confirm `PoolDeletion.status_at_delete` is spelled correctly (it is)
+
+3. **Create `docs/superpowers/specs/YYYY-MM-DD-ops-51-data-model.md`**
+   - Document the source/derived distinction
+   - Document hole-level scoring status (not implemented)
+   - Include entity-relationship summary for new developers
+
+4. **Verify no other type files exist**
+   - Check for any other TypeScript files defining database types
+   - Consolidate to `types.ts` as single source
+
+## Out of Scope
+
+- Provider migration changes
+- UI work
+- Non-MVP feature expansion
+- Actually implementing `tournament_holes` (OPS-50)
+
+## Acceptance Criteria
+
+1. `schema.sql` matches the canonical schema exactly (verified by comparing to migration output)
+2. `types.ts` `PoolDeletion.status_at_delete` field name matches actual table column
+3. `types.ts` `Golfer` interface fields match `golfers` table columns exactly
+4. A new developer can read `schema.sql` and understand the actual runtime data model
+5. `docs/superpowers/specs/YYYY-MM-DD-ops-51-data-model.md` explains source vs derived values clearly
+6. Hole-level scoring storage has a clear documented status (not implemented, pending OPS-50)
+
+## Alternative Approaches
+
+### A) Auto-generate types from Supabase CLI
+Supabase CLI can generate TypeScript types from the database schema via `supabase gen types typescript`.
+
+**Problem:** This would overwrite the carefully crafted type names and comments. The current `types.ts` was written to be developer-friendly, not auto-generated. Auto-generation is appropriate for greenfield projects, not this codebase.
+
+### B) Keep schema.sql as-is, document the discrepancy
+**Problem:** The drift would remain. New developers would still get wrong information. This delays the problem rather than solving it.
+
+### C) Delete schema.sql entirely, use Supabase dashboard as documentation
+**Problem:** Supabase dashboard requires login. Schema.sql provides offline reference. Keep it accurate.
+
+**Recommended:** Option A with manual oversight — update `schema.sql` to match migrations exactly, keep `types.ts` as the canonical TypeScript interface source (with manual sync discipline).

--- a/docs/superpowers/specs/2026-04-26-ops-52-slash-golf-scorecard-driven-scoring-flow-design.md
+++ b/docs/superpowers/specs/2026-04-26-ops-52-slash-golf-scorecard-driven-scoring-flow-design.md
@@ -1,0 +1,368 @@
+---
+name: OPS-52 Integrate Slash Golf scorecard-driven scoring flow
+description: Build a clean multi-endpoint adapter layer for Slash Golf tournament/leaderboard/scorecard flows with status normalization, fixture capture, and selective scorecard refresh strategy
+module: scoring / provider-adapter
+tags: [scoring, slash-golf, provider-adapter, hole-level, scorecard]
+git_refs: []
+problem_type: feature
+date: 2026-04-26
+---
+
+# OPS-52: Integrate Slash Golf Scorecard-Driven Scoring Flow
+
+## Problem
+
+The app currently relies on aggregate leaderboard data as the sole scoring source of truth. OPS-50 identified that true hole-level best-ball scoring requires per-hole data. The Slash Golf API provides `/tournament`, `/leaderboard`, `/scorecard`, and `/stats` endpoints, but no clean adapter strategy exists for using them together.
+
+The deliverable is a documented, tested provider adapter layer that:
+- Uses the correct endpoints for each data type
+- Normalizes player status values including `complete` / `wd` / `dq` / `cut`
+- Captures real payload fixtures
+- Defines an explicit selective scorecard fetch strategy
+
+## What Exists Today
+
+### `src/lib/slash-golf/client.ts` (current state)
+
+| Function | Endpoint | Status |
+|----------|-----------|--------|
+| `getTournamentScores(tournamentId, year)` | `GET /leaderboard` | Works, normalizes leaderboard rows |
+| `getGolfers(tournamentId, year)` | `GET /tournament` | Works, normalizes player array |
+
+**Missing:**
+- No `/scorecard` endpoint integration
+- No `/stats` endpoint integration
+- No fixture capture for any endpoint
+- Status normalization only handles `'withdrawn'` / `'cut'` → `'active'`; does not handle `'complete'`, `'dq'`
+- No `tournament_holes` table integration (per OPS-50 spec)
+- No documented call strategy for selective scorecard refreshes
+
+### `src/lib/slash-golf/types.ts`
+
+`GolferScoreRound` already exists as a type that maps to the leaderboard round structure. It does **not** have hole-level fields.
+
+## Design
+
+### 1. New Endpoint Functions in `client.ts`
+
+#### `getTournamentMeta(tournamentId: string, year?: number): Promise<SlashTournamentMeta>`
+
+Hits `GET /tournament`. Returns tournament-level metadata: field status, course info, round count.
+
+```ts
+export interface SlashTournamentMeta {
+  tournId: string
+  name: string
+  year: string
+  status: 'published' | 'In Progress' | 'Complete' | 'Canceled'
+  currentRound: number | null
+  courses: Array<{ courseId: string; courseName: string }>
+  format: string | null
+  date: string | null
+}
+```
+
+#### `getLeaderboard(tournamentId: string, year?: number): Promise<SlashLeaderboard>`
+
+Hits `GET /leaderboard`. Returns tournament status, round progress, and refresh targeting info.
+
+```ts
+export interface SlashLeaderboard {
+  tournId: string
+  year: string
+  status: 'In Progress' | 'Round Complete' | 'Tournament Complete' | string
+  roundId: number
+  roundStatus: 'In Progress' | 'Round Complete' | 'Pre' | string
+  timestamp: string
+  leaderboardRows: SlashGolferRow[]
+}
+```
+
+**Refresh targeting use:** `roundStatus === 'In Progress'` means live scoring — cron should refresh at higher frequency. `roundStatus === 'Round Complete'` means round boundary — scorecard fetch is worthwhile.
+
+#### `getScorecard(tournamentId: string, golferId: string, year?: number): Promise<SlashScorecard>`
+
+Hits `GET /scorecard`. Returns per-player hole scores for one golfer.
+
+```ts
+export interface SlashScorecard {
+  tournId: string
+  playerId: string
+  year: string
+  status: SlashGolferStatus
+  currentRound: number
+  holes: SlashHole[]
+}
+
+export interface SlashHole {
+  holeId: number        // 1–18
+  par: number
+  strokes: number
+  scoreToPar: number   // strokes - par
+}
+
+export type SlashGolferStatus = 'active' | 'withdrawn' | 'cut' | 'dq' | 'complete'
+```
+
+#### `getStats(tournamentId: string, year?: number): Promise<SlashStats>`
+
+Hits `GET /stats`. For ranking-tier features. Returns world ranking changes, OWGR points.
+
+```ts
+export interface SlashStats {
+  tournId: string
+  playerId: string
+  worldRank: number | null
+  projectedOWGR: number | null
+  // ...
+}
+```
+
+**MVP scope note:** Stats endpoint is not needed for current MVP scoring. Included for near-term compatibility only.
+
+### 2. Status Normalization
+
+The Slash Golf API uses diverse status values. The normalizer must handle all observed variants:
+
+| Raw Value | Normalized |
+|----------|------------|
+| `'active'`, `'In Progress'` (round), `'playing'` | `'active'` |
+| `'withdrawn'`, `'wd'`, `'WD'` | `'withdrawn'` |
+| `'cut'`, `'cu'`, `'CUT'` | `'cut'` |
+| `'dq'`, `'DQ'` | `'dq'` |
+| `'complete'`, `'finished'`, `'F'` | `'complete'` |
+| `null`, `undefined`, `''` | `'active'` (default) |
+
+```ts
+export function normalizeSlashStatus(status: unknown): SlashGolferStatus {
+  if (typeof status !== 'string') return 'active'
+  const s = status.trim().toLowerCase()
+  if (s === 'withdrawn' || s === 'wd') return 'withdrawn'
+  if (s === 'cut' || s === 'cu') return 'cut'
+  if (s === 'dq') return 'dq'
+  if (s === 'complete' || s === 'finished' || s === 'f') return 'complete'
+  return 'active'
+}
+```
+
+The `GolferStatus` union in `supabase/types.ts` (`'active' | 'withdrawn' | 'cut'`) must be extended to include `'dq'` and `'complete'`:
+
+```ts
+export type GolferStatus = 'active' | 'withdrawn' | 'cut' | 'dq' | 'complete'
+```
+
+Note: `'complete'` means the golfer finished the tournament. `'active'` means currently playing. Both are distinct from cut/WD/DQ.
+
+### 3. Tournament Holes Table (Per OPS-50)
+
+Per the OPS-50 design spec, hole-level data must be stored in `tournament_holes`:
+
+```ts
+export interface TournamentHole {
+  golfer_id: string
+  tournament_id: string
+  round_id: number
+  hole_id: number      // 1–18
+  strokes: number
+  par: number
+  score_to_par: number
+  updated_at?: string
+}
+```
+
+New function in `scoring-queries.ts`:
+
+```ts
+export async function upsertTournamentHoles(
+  supabase: SupabaseClient,
+  holes: TournamentHole[]
+): Promise<{ error: string | null }>
+```
+
+### 4. Selective Scorecard Refresh Strategy
+
+Fetching `/scorecard` per golfer on every refresh would be expensive (156 golfers × 4 rounds × 18 holes = 11,232 potential API calls per tournament refresh cycle). A selective strategy is required.
+
+**Strategy:**
+
+| Condition | Action |
+|-----------|--------|
+| Round is not yet complete (`roundStatus !== 'Round Complete'`) | Skip scorecard fetch — leaderboard rounds data is sufficient |
+| Round just completed (`roundStatus === 'Round Complete'` for first time) | Fetch scorecard for all rostered golfers to lock in hole data |
+| Tournament is live and in progress | Only fetch scorecard for golfers whose leaderboard row shows `thru < 18` (incomplete round) |
+| Golfer was cut/WD/DQ | Fetch scorecard once to capture final hole, then mark golfer as inactive |
+| Golfer has no `tournament_holes` data for a completed round | Fetch scorecard to backfill |
+
+**Implementation:**
+A new `ScorecardFetchPlan` type describes which golfers need scorecard fetches:
+
+```ts
+export interface ScorecardFetchPlan {
+  tournamentId: string
+  year: number
+  fetchScorecard: Array<{ golferId: string; reason: 'round_complete_backfill' | 'in_progress_refresh' | 'status_change' }>
+  skipScorecard: Array<{ golferId: string; reason: string }>
+}
+```
+
+```ts
+export function buildScorecardFetchPlan(
+  meta: SlashTournamentMeta,
+  leaderboard: SlashLeaderboard,
+  existingHoleCounts: Map<string, number>  // golferId → count of stored holes
+): ScorecardFetchPlan
+```
+
+The plan is consumed by a batch fetcher that calls `getScorecard` per golfer with rate limiting (sequential or capped concurrency to avoid API quota exhaustion).
+
+### 5. Call Strategy Documentation
+
+A strategy doc at `docs/superpowers/specs/ops-52-call-strategy.md` will document:
+
+- Which endpoint to call when
+- How to correlate round state from leaderboard with scorecard data needs
+- Rate limiting assumptions (RapidAPI tier limits)
+- Error handling per endpoint (fetch failures, empty responses, malformed data)
+- Quota budgeting across tournament + leaderboard + scorecard calls
+
+### 6. Type Additions
+
+```ts
+// src/lib/slash-golf/types.ts
+
+export interface SlashTournamentMeta {
+  tournId: string
+  name: string
+  year: string
+  status: string
+  currentRound: number | null
+  courses: Array<{ courseId: string; courseName: string }>
+  format: string | null
+  date: string | null
+}
+
+export interface SlashLeaderboard {
+  tournId: string
+  year: string
+  status: string
+  roundId: number
+  roundStatus: string
+  timestamp: string
+  leaderboardRows: SlashGolferRow[]
+}
+
+export interface SlashGolferRow {
+  playerId: string
+  lastName: string
+  firstName: string
+  isAmateur: boolean
+  status: SlashGolferStatus
+  currentRound: number
+  total: string | { $numberInt: string }
+  currentRoundScore: string | { $numberInt: string }
+  position: string | null
+  totalStrokesFromCompletedRounds: string | null
+  rounds: SlashRound[]
+  thru: string | null
+  startingHole: number | null
+  currentHole: number | null
+  courseId: string | null
+  teeTime: string | null
+  teeTimeTimestamp: string | null
+}
+
+export interface SlashRound {
+  roundId: number
+  courseId: string
+  courseName: string
+  strokes: number | { $numberInt: string }
+  scoreToPar: number | { $numberInt: string }
+}
+
+export interface SlashHole {
+  holeId: number
+  par: number
+  strokes: number
+  scoreToPar: number
+}
+
+export interface SlashScorecard {
+  tournId: string
+  playerId: string
+  year: string
+  status: SlashGolferStatus
+  currentRound: number
+  holes: SlashHole[]
+}
+
+export type SlashGolferStatus = 'active' | 'withdrawn' | 'cut' | 'dq' | 'complete'
+```
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `src/lib/slash-golf/types.ts` | Add `SlashTournamentMeta`, `SlashLeaderboard`, `SlashGolferRow`, `SlashRound`, `SlashHole`, `SlashScorecard`, `SlashGolferStatus` |
+| `src/lib/slash-golf/client.ts` | Add `getTournamentMeta`, `getLeaderboard`, `getScorecard`, `getStats` functions; update `normalizeGolferStatus` |
+| `src/lib/supabase/types.ts` | Extend `GolferStatus` to include `'dq' \| 'complete'` |
+| `src/lib/scoring-queries.ts` | Add `upsertTournamentHoles` |
+| `docs/superpowers/specs/ops-52-call-strategy.md` | New — call strategy documentation |
+
+## Payload Fixtures
+
+Capture real payloads for:
+- `GET /tournament` response shape
+- `GET /leaderboard` response shape
+- `GET /scorecard` response shape
+- `GET /stats` response shape (if available)
+
+Fixtures directory: `fixtures/slash-golf/` with files:
+- `tournament-{tournamentId}.json`
+- `leaderboard-{tournamentId}.json`
+- `scorecard-{tournamentId}-{golferId}.json`
+- `stats-{tournamentId}-{golferId}.json`
+
+Each fixture includes a header comment with:
+- Capture date
+- Tournament ID
+- Source endpoint
+- Any notable observations (e.g., "status field uses 'complete' not 'finished'")
+
+## Out of Scope
+
+- Actual `tournament_holes` table creation and population (OPS-50 scope)
+- Cron pipeline changes to use the new scorecard fetch strategy (OPS-29 scope)
+- UI changes to display hole-level scoring (OPS-50/OPS-32 scope)
+- Switching away from Slash Golf
+
+## Dependencies
+
+- OPS-51 (Supabase schema reconciliation) — schema types must be stable before adapter typing
+- OPS-50 (scoring engine rebuild) — `tournament_holes` table must exist before scorecard data can be persisted
+- OPS-49 (MVP rules freeze) — status normalization rules must be finalized
+
+## Acceptance Criteria
+
+1. All four Slash Golf endpoints (`/tournament`, `/leaderboard`, `/scorecard`, `/stats`) have typed adapter functions in `client.ts`
+2. Status normalization handles `'complete'`, `'dq'`, `'wd'` (in addition to existing `'withdrawn'`/`'cut'`)
+3. `GolferStatus` in `types.ts` includes `'dq'` and `'complete'`
+4. `upsertTournamentHoles` function exists in `scoring-queries.ts`
+5. At least one real payload fixture is captured and committed for each endpoint
+6. Call strategy doc exists at `docs/superpowers/specs/ops-52-call-strategy.md`
+7. No leaderboard aggregates are used as sole scoring source of truth — scorecard data can replace them
+
+## Alternative Approaches
+
+### A) Extend existing `getTournamentScores` to also fetch scorecard (not recommended)
+
+Adding scorecard logic into the existing function would violate single-responsibility. The current function already handles 3 response shapes. It would become unmaintainable.
+
+### B) Create separate adapter files per endpoint (e.g., `slash-golf/tournament.ts`, `slash-golf/scorecard.ts`)
+
+Too fine-grained. All Slash Golf provider logic belongs in one module with consistent error handling and rate limiting. A single `client.ts` with named exports is sufficient.
+
+### C) Use GraphQL wrapper over REST endpoints
+
+Not supported by the Slash Golf API. REST only.
+
+**Recommended:** Single `client.ts` module with clearly named functions per endpoint. Consistent error handling, shared status normalization, fixture capture for all endpoints.

--- a/docs/superpowers/specs/2026-04-26-ops-57-fix-score-trace-build-design.md
+++ b/docs/superpowers/specs/2026-04-26-ops-57-fix-score-trace-build-design.md
@@ -1,0 +1,59 @@
+# OPS-57: Fix build failure in score-trace page — Design Spec
+
+## Problem
+
+The Next.js production build fails with a type error in `src/app/(app)/commissioner/pools/[poolId]/audit/score-trace/page.tsx:175`:
+
+```
+Type error: Type 'number | null' is not assignable to type 'number'.
+  Type 'null' is not assignable to type 'number'.
+```
+
+## Root Cause
+
+- `rankEntries()` (in `src/lib/scoring/domain.ts:123`) returns `Entry & { totalScore: number | null; ... }`
+- `ScoreDisplay` component (in `src/components/score-display.tsx`) accepts prop type `{ score: number }` — does not accept `null`
+- Line 175 passes `entry.totalScore` directly to `<ScoreDisplay>` without guarding against `null`
+
+```typescript
+// rankEntries return type (domain.ts:127)
+(Entry & { totalScore: number | null; totalBirdies: number; completedHoles: number; rank: number; isTied: boolean })[]
+
+// ScoreDisplay prop type (score-display.tsx:1)
+export function ScoreDisplay({ score }: { score: number }) { ... }
+```
+
+## Fix Approach
+
+**Chosen approach: Null guard in score-trace page**
+
+In `score-trace/page.tsx`, guard `entry.totalScore` at the two call sites of `ScoreDisplay`:
+
+- Line 175: `<ScoreDisplay score={entry.totalScore} />` → `<ScoreDisplay score={entry.totalScore ?? 0} />`
+- Line 178: `<ScoreDisplay score={row.roundScore ?? 0} />` (same pattern for consistency)
+
+`row.roundScore` comes from `golferScore.total_score ?? null` and is already passed through `ScoreDisplay` on line 212, so the same null guard is needed there too.
+
+## Why not modify ScoreDisplay?
+
+`ScoreDisplay` is a shared UI primitive used across leaderboards and scorecards. Changing it to accept `number | null` would:
+1. Require updating all 18+ call sites to handle the null semantics appropriately
+2. Obscure the distinction between "score is 0" and "no score available" in user-facing displays
+
+The score-trace page is an audit/development tool — treating null as 0 here is acceptable because the surrounding UI already communicates the "no scores yet" state differently.
+
+## No Changes to Entry type or rankEntries signature
+
+The `Entry` interface in `types.ts` does not include `totalScore` — that is an additional field injected by `rankEntries`. The return type of `rankEntries` correctly reflects that totalScore can be null when no golfer scores are available.
+
+## Files to Modify
+
+1. `src/app/(app)/commissioner/pools/[poolId]/audit/score-trace/page.tsx`
+   - Line 175: Add `?? 0` null coalescing on `entry.totalScore`
+   - Lines 209-212: Add `?? 0` null coalescing on `row.roundScore`
+
+## Verification
+
+1. `npm run build` completes without type errors
+2. `npm run typecheck` passes (if available)
+3. Page renders in dev mode without runtime errors

--- a/docs/superpowers/specs/ops-52-call-strategy.md
+++ b/docs/superpowers/specs/ops-52-call-strategy.md
@@ -1,0 +1,176 @@
+# OPS-52 Call Strategy — Slash Golf Multi-Endpoint Integration
+
+## Endpoint Overview
+
+| Endpoint | Function | When to Call | Data It Provides |
+|----------|----------|--------------|-----------------|
+| `GET /tournament` | `getTournamentMeta()` | On pool open; on demand | Field list, course info, tournament status |
+| `GET /leaderboard` | `getLeaderboard()` | Every refresh cycle (cron + on-demand) | Round status, player status, refresh targeting |
+| `GET /scorecard` | `getScorecard()` | Selective (see below) | Per-hole strokes for one golfer |
+| `GET /stats` | `getStats()` | Not in MVP scope | World rank, OWGR projections |
+
+## Refresh Targeting via Leaderboard
+
+The `leaderboard.roundStatus` field drives the scorecard fetch strategy:
+
+| `roundStatus` | Meaning | Action |
+|---------------|---------|--------|
+| `'Pre'` | Round not started | Skip scorecard fetches |
+| `'In Progress'` | Live round | Only fetch scorecard for golfers with `thru < 18` |
+| `'Round Complete'` | Round just finished | Fetch scorecard for all rostered golfers to lock hole data |
+| `'Tournament Complete'` | Tournament over | Fetch scorecards for any golfers missing hole data |
+
+## Selective Scorecard Fetch Logic
+
+### ScorecardFetchPlan
+
+```ts
+interface ScorecardFetchPlan {
+  tournamentId: string
+  year: number
+  fetchScorecard: Array<{
+    golferId: string
+    reason: 'round_complete_backfill' | 'in_progress_refresh' | 'status_change'
+  }>
+  skipScorecard: Array<{
+    golferId: string
+    reason: string
+  }>
+}
+```
+
+### Decision Rules (implement in scoring-refresh.ts)
+
+```
+GIVEN leaderboard data for a tournament + existing hole counts per golfer:
+
+FOR each golfer in leaderboardRows:
+  1. If roundStatus === 'Pre':
+     - Skip scorecard. No round has started.
+
+  2. If roundStatus === 'Round Complete' AND golfer has fewer than 18 holes stored:
+     - Fetch scorecard (reason: 'round_complete_backfill')
+
+  3. If roundStatus === 'In Progress':
+     - If golfer.thru < 18 AND golfer.status === 'active':
+       - Fetch scorecard (reason: 'in_progress_refresh')
+     - Else skip.
+
+  4. If golfer.status just changed (active -> cut/wd/dq):
+     - Fetch scorecard once to capture final state (reason: 'status_change')
+     - After fetch, mark golfer inactive for subsequent refreshes.
+
+  5. If golfer has 0 holes stored for a completed round:
+     - Fetch scorecard (reason: 'round_complete_backfill')
+
+  6. Otherwise skip.
+```
+
+## Rate Limiting
+
+RapidAPI Slash Golf tier limits apply. Default tier: ~100 calls/minute.
+
+**Budget per refresh cycle (assumes 156 golfers, 4 rounds):**
+
+| Operation | Calls | Budget |
+|-----------|-------|--------|
+| Tournament meta | 1 | Fixed |
+| Leaderboard | 1 | Fixed |
+| Scorecard (backfill all rostered after round complete) | 156 | 1.6s at 100/min |
+| Scorecard (in-progress only for active golfers with thru < 18) | ~50 | 0.5s at 100/min |
+| Stats | 0 (out of MVP scope) | — |
+
+**Rate limit strategy:** Call `getScorecard` sequentially (not parallel) to stay within RapidAPI limits. Add a 600ms delay between scorecard calls. Alternatively, use a concurrency cap of 3.
+
+```ts
+async function fetchScorecardsWithRateLimit(
+  fetches: Array<() => Promise<SlashScorecard>>,
+  maxConcurrent = 3,
+  delayMs = 600
+): Promise<SlashScorecard[]> {
+  const results: SlashScorecard[] = []
+  for (let i = 0; i < fetches.length; i += maxConcurrent) {
+    const batch = fetches.slice(i, i + maxConcurrent)
+    const batchResults = await Promise.all(batch.map(f => f()))
+    results.push(...batchResults)
+    if (i + maxConcurrent < fetches.length) {
+      await new Promise(resolve => setTimeout(resolve, delayMs))
+    }
+  }
+  return results
+}
+```
+
+## Error Handling Per Endpoint
+
+### Tournament Meta
+- 404: Tournament not published → throw `'Tournament field has not been published yet.'`
+- 429: Rate limited → exponential backoff, max 3 retries
+- 5xx: Server error → fail open with warning (tournament metadata is non-critical)
+
+### Leaderboard
+- Empty `leaderboardRows`: Log warning, return empty array. Do not throw.
+- 429: Rate limited → exponential backoff, max 3 retries
+- Network error → throw so cron can retry on next cycle
+
+### Scorecard
+- 404 for individual golfer → log and skip (golfer may have withdrawn before any data)
+- 429: Rate limited → wait and retry once; if still limited, skip
+- Per-golfer errors must not fail the entire refresh cycle
+
+### Stats
+- Not called in MVP. Errors are logged but non-fatal.
+
+## Quota Tracking
+
+Track API calls per refresh to stay within daily/monthly RapidAPI quotas.
+
+```ts
+let apiCallsThisCycle = 0
+
+async function refreshWithQuotaTracking(pool: RefreshablePool) {
+  // leaderboard call
+  const board = await getLeaderboard(pool.tournamentId, pool.year)
+  apiCallsThisCycle++
+
+  // scorecard calls (rate-limited)
+  for (const fetch of scorecardFetches) {
+    if (apiCallsThisCycle >= QUOTA_LIMIT) {
+      console.warn('[slash-golf] quota limit reached, skipping remaining scorecards')
+      break
+    }
+    await fetch()
+    apiCallsThisCycle++
+  }
+}
+```
+
+## Out-of-Scope Details
+
+- Tournament hole data storage: handled by `upsertTournamentHoles` (OPS-50)
+- Cron scheduling/frequency: handled by OPS-29
+- Real-time scorecard updates during live play: future work
+
+## Fixture Capture
+
+Capture real payloads for CI reproducibility:
+
+```
+fixtures/slash-golf/
+  tournament-{tournamentId}.json    # from /tournament endpoint
+  leaderboard-{tournamentId}.json  # from /leaderboard endpoint
+  scorecard-{tournamentId}-{golferId}.json  # from /scorecard endpoint
+  stats-{tournamentId}-{golferId}.json       # from /stats endpoint
+```
+
+Fixture files should include a JSON comment header:
+```json
+{
+  // fixture: slash-golf scorecard
+  // tournamentId: 014
+  // golferId: 22405
+  // captured: 2026-04-10
+  // note: "status field uses 'complete' not 'finished'"
+  ...
+}
+```

--- a/fixtures/slash-golf/leaderboard-STUB.json
+++ b/fixtures/slash-golf/leaderboard-STUB.json
@@ -1,0 +1,39 @@
+{
+  // fixture: Slash Golf /leaderboard response
+  // tournamentId: <fill in from live API>
+  // captured: <date>
+  // note: Capture real response from GET /leaderboard?orgId=1&tournId=<id>
+  "orgId": "1",
+  "year": "2026",
+  "tournId": "014",
+  "status": "In Progress",
+  "roundId": 2,
+  "roundStatus": "In Progress",
+  "timestamp": "2026-04-10T15:23:33.217000",
+  "leaderboardRows": [
+    {
+      "playerId": "22405",
+      "lastName": "Rose",
+      "firstName": "Justin",
+      "isAmateur": false,
+      "status": "active",
+      "currentRound": 2,
+      "total": "-1",
+      "currentRoundScore": "+1",
+      "position": "T11",
+      "totalStrokesFromCompletedRounds": "70",
+      "rounds": [
+        {
+          "roundId": 1,
+          "courseId": "014",
+          "courseName": "Augusta National Golf Club",
+          "strokes": 70,
+          "scoreToPar": "-2"
+        }
+      ],
+      "thru": "4",
+      "startingHole": 1,
+      "currentHole": 5
+    }
+  ]
+}

--- a/fixtures/slash-golf/scorecard-STUB.json
+++ b/fixtures/slash-golf/scorecard-STUB.json
@@ -1,0 +1,18 @@
+{
+  // fixture: Slash Golf /scorecard response
+  // tournamentId: 014
+  // golferId: <fill in from live API>
+  // captured: <date>
+  // note: Capture real response from GET /scorecard?orgId=1&tournId=014&playerId=<id>
+  "tournId": "014",
+  "playerId": "22405",
+  "year": "2026",
+  "status": "active",
+  "currentRound": 2,
+  "holes": [
+    { "holeId": 1, "par": 4, "strokes": 4, "scoreToPar": 0 },
+    { "holeId": 2, "par": 5, "strokes": 4, "scoreToPar": -1 },
+    { "holeId": 3, "par": 4, "strokes": 3, "scoreToPar": -1 },
+    { "holeId": 4, "par": 4, "strokes": 5, "scoreToPar": 1 }
+  ]
+}

--- a/fixtures/slash-golf/stats-STUB.json
+++ b/fixtures/slash-golf/stats-STUB.json
@@ -1,0 +1,11 @@
+{
+  // fixture: Slash Golf /stats response
+  // tournamentId: 014
+  // golferId: <fill in from live API>
+  // captured: <date>
+  // note: Capture real response from GET /stats?orgId=1&tournId=014&playerId=<id>
+  "tournId": "014",
+  "playerId": "22405",
+  "worldRank": 12,
+  "projectedOWGR": 8.5
+}

--- a/fixtures/slash-golf/tournament-STUB.json
+++ b/fixtures/slash-golf/tournament-STUB.json
@@ -1,0 +1,17 @@
+{
+  // fixture: Slash Golf /tournament response
+  // tournamentId: <fill in from live API>
+  // captured: <date>
+  // note: Capture real response from GET /tournament?orgId=1&tournId=<id>
+  "orgId": "1",
+  "year": "2026",
+  "tournId": "014",
+  "name": "The Masters",
+  "status": "In Progress",
+  "currentRound": 2,
+  "courses": [
+    { "courseId": "014", "courseName": "Augusta National Golf Club" }
+  ],
+  "format": "stroke",
+  "date": "2026-04-10"
+}

--- a/src/lib/__tests__/scoring-queries.test.ts
+++ b/src/lib/__tests__/scoring-queries.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { upsertTournamentScore } from '../scoring-queries'
+import { upsertTournamentHoles, upsertTournamentScore } from '../scoring-queries'
 
 describe('upsertTournamentScore', () => {
   beforeEach(() => {
@@ -163,5 +163,30 @@ describe('upsertTournamentScore', () => {
     for (const record of archiveUpserts) {
       expect(record).not.toHaveProperty('round_status')
     }
+  })
+
+  it('upsertTournamentHoles persists hole records', async () => {
+    const upsertedRecords: unknown[] = []
+
+    const builder: any = {
+      upsert: vi.fn((records: unknown) => {
+        upsertedRecords.push(...(Array.isArray(records) ? records : [records]))
+        return builder
+      }),
+      then: (onFulfilled: (value: { error: null }) => unknown, onRejected?: (reason: unknown) => unknown) =>
+        Promise.resolve({ error: null }).then(onFulfilled, onRejected),
+    }
+
+    const supabase = {
+      from: vi.fn(() => builder),
+    } as never
+
+    const holes = [
+      { golfer_id: 'g1', tournament_id: 't1', round_id: 1, hole_id: 1, strokes: 4, par: 4, score_to_par: 0 },
+      { golfer_id: 'g1', tournament_id: 't1', round_id: 1, hole_id: 2, strokes: 5, par: 4, score_to_par: 1 },
+    ]
+    const result = await upsertTournamentHoles(supabase, holes)
+    expect(result.error).toBeNull()
+    expect(upsertedRecords).toHaveLength(2)
   })
 })

--- a/src/lib/__tests__/slash-golf-client.test.ts
+++ b/src/lib/__tests__/slash-golf-client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { getTournamentScores } from '@/lib/slash-golf/client'
+import { getScorecard, getLeaderboard, getStats, getTournamentMeta, getTournamentScores } from '@/lib/slash-golf/client'
 
 describe('getTournamentScores', () => {
   afterEach(() => {
@@ -164,5 +164,56 @@ describe('getTournamentScores', () => {
     const round = golfer.rounds![0]!
     expect(round.score_to_par).toBe(0)
     expect(round.strokes).toBe(72)
+  })
+
+  it('getTournamentMeta returns normalized tournament metadata', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        orgId: '1',
+        year: '2026',
+        tournId: '014',
+        name: 'The Masters',
+        status: 'In Progress',
+        currentRound: 2,
+        courses: [{ courseId: '014', courseName: 'Augusta National Golf Club' }],
+        format: 'stroke',
+        date: '2026-04-10',
+      }),
+    }))
+
+    const meta = await getTournamentMeta('014', 2026)
+    expect(meta).toMatchObject({
+      tournId: '014',
+      name: 'The Masters',
+      year: '2026',
+      status: 'In Progress',
+      currentRound: 2,
+      courses: [{ courseId: '014', courseName: 'Augusta National Golf Club' }],
+    })
+  })
+
+  it('getLeaderboard returns normalized leaderboard with round status', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        orgId: '1',
+        year: '2026',
+        tournId: '014',
+        status: 'In Progress',
+        roundId: 2,
+        roundStatus: 'In Progress',
+        timestamp: '2026-04-10T15:23:33.217000',
+        leaderboardRows: [
+          { playerId: '22405', lastName: 'Rose', firstName: 'Justin', isAmateur: false, status: 'active' },
+        ],
+      }),
+    }))
+
+    const board = await getLeaderboard('014', 2026)
+    expect(board.tournId).toBe('014')
+    expect(board.roundStatus).toBe('In Progress')
+    expect(board.leaderboardRows).toHaveLength(1)
+    expect(board.leaderboardRows[0].status).toBe('active')
   })
 })

--- a/src/lib/__tests__/slash-golf-client.test.ts
+++ b/src/lib/__tests__/slash-golf-client.test.ts
@@ -216,4 +216,44 @@ describe('getTournamentScores', () => {
     expect(board.leaderboardRows).toHaveLength(1)
     expect(board.leaderboardRows[0].status).toBe('active')
   })
+
+  it('getScorecard returns per-hole scorecard for a golfer', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        tournId: '014',
+        playerId: '22405',
+        year: '2026',
+        status: 'active',
+        currentRound: 2,
+        holes: [
+          { holeId: 1, par: 4, strokes: 4, scoreToPar: 0 },
+          { holeId: 2, par: 5, strokes: 4, scoreToPar: -1 },
+        ],
+      }),
+    }))
+
+    const scorecard = await getScorecard('014', '22405', 2026)
+    expect(scorecard.tournId).toBe('014')
+    expect(scorecard.playerId).toBe('22405')
+    expect(scorecard.holes).toHaveLength(2)
+    expect(scorecard.holes[0]).toMatchObject({ holeId: 1, par: 4, scoreToPar: 0 })
+    expect(scorecard.holes[1]).toMatchObject({ holeId: 2, par: 5, scoreToPar: -1 })
+  })
+
+  it('getStats returns player ranking stats', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        tournId: '014',
+        playerId: '22405',
+        worldRank: 12,
+        projectedOWGR: 8.5,
+      }),
+    }))
+
+    const stats = await getStats('014', '22405', 2026)
+    expect(stats.playerId).toBe('22405')
+    expect(stats.worldRank).toBe(12)
+  })
 })

--- a/src/lib/scoring-queries.ts
+++ b/src/lib/scoring-queries.ts
@@ -2,6 +2,17 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import type { TournamentScore, TournamentScoreRound } from './supabase/types'
 import type { GolferScore, GolferScoreRound } from './slash-golf/types'
 
+export interface TournamentHole {
+  golfer_id: string
+  tournament_id: string
+  round_id: number
+  hole_id: number
+  strokes: number
+  par: number
+  score_to_par: number
+  updated_at?: string
+}
+
 export async function upsertTournamentScoreRound(
   supabase: SupabaseClient,
   score: Omit<TournamentScoreRound, 'id'>
@@ -106,4 +117,26 @@ export async function getTournamentScoreRounds(
     .eq('tournament_id', tournamentId)
     .order('round_id', { ascending: true })
   return (data as TournamentScoreRound[]) || []
+}
+
+export async function upsertTournamentHoles(
+  supabase: SupabaseClient,
+  holes: TournamentHole[]
+): Promise<{ error: string | null }> {
+  if (holes.length === 0) return { error: null }
+  const records = holes.map(h => ({
+    golfer_id: h.golfer_id,
+    tournament_id: h.tournament_id,
+    round_id: h.round_id,
+    hole_id: h.hole_id,
+    strokes: h.strokes,
+    par: h.par,
+    score_to_par: h.score_to_par,
+    updated_at: h.updated_at ?? new Date().toISOString(),
+  }))
+  const { error } = await supabase
+    .from('tournament_holes')
+    .upsert(records, { onConflict: 'golfer_id,tournament_id,round_id,hole_id' })
+  if (error) return { error: error.message }
+  return { error: null }
 }

--- a/src/lib/slash-golf/client.ts
+++ b/src/lib/slash-golf/client.ts
@@ -1,4 +1,4 @@
-import type { Tournament, GolferScore, GolferScoreRound, SlashTournamentMeta, SlashLeaderboard, SlashGolferStatus } from './types'
+import type { Tournament, GolferScore, GolferScoreRound, SlashTournamentMeta, SlashLeaderboard, SlashGolferStatus, SlashScorecard, SlashHole, SlashStats } from './types'
 
 const BASE_URL = 'https://live-golf-data.p.rapidapi.com'
 
@@ -313,5 +313,50 @@ export async function getLeaderboard(tournamentId: string, year?: number): Promi
       teeTime: typeof row.teeTime === 'string' ? row.teeTime : null,
       teeTimeTimestamp: typeof row.teeTimeTimestamp === 'string' ? row.teeTimeTimestamp : null,
     })),
+  }
+}
+
+export async function getScorecard(tournamentId: string, golferId: string, year?: number): Promise<SlashScorecard> {
+  const params = new URLSearchParams({ orgId: '1', tournId: tournamentId, playerId: golferId, ...(year && { year: year.toString() }) })
+  const res = await fetch(`${BASE_URL}/scorecard?${params}`, {
+    headers: { 'X-RapidAPI-Key': process.env.SLASH_GOLF_API_KEY ?? '' },
+    cache: 'no-store'
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    console.error('[slash-golf] scorecard fetch failed', { status: res.status, golferId, body })
+    throw new Error('Failed to fetch scorecard')
+  }
+  const raw = await res.json()
+  const holes = Array.isArray(raw.holes) ? raw.holes.map((h: Record<string, unknown>) => ({
+    holeId: parseMongoNumber(h.holeId) ?? 0,
+    par: parseMongoNumber(h.par) ?? 0,
+    strokes: parseMongoNumber(h.strokes) ?? 0,
+    scoreToPar: parseMongoNumber(h.scoreToPar) ?? 0,
+  })).filter((h: SlashHole) => h.holeId > 0) : []
+
+  return {
+    tournId: typeof raw.tournId === 'string' ? raw.tournId : tournamentId,
+    playerId: typeof raw.playerId === 'string' ? raw.playerId : golferId,
+    year: typeof raw.year === 'string' ? raw.year : (year?.toString() ?? ''),
+    status: normalizeSlashStatus(raw.status),
+    currentRound: parseMongoNumber(raw.currentRound) ?? 1,
+    holes,
+  }
+}
+
+export async function getStats(tournamentId: string, golferId: string, year?: number): Promise<SlashStats> {
+  const params = new URLSearchParams({ orgId: '1', tournId: tournamentId, playerId: golferId, ...(year && { year: year.toString() }) })
+  const res = await fetch(`${BASE_URL}/stats?${params}`, {
+    headers: { 'X-RapidAPI-Key': process.env.SLASH_GOLF_API_KEY ?? '' },
+    cache: 'no-store'
+  })
+  if (!res.ok) throw new Error('Failed to fetch stats')
+  const raw = await res.json()
+  return {
+    tournId: typeof raw.tournId === 'string' ? raw.tournId : tournamentId,
+    playerId: typeof raw.playerId === 'string' ? raw.playerId : golferId,
+    worldRank: typeof raw.worldRank === 'number' ? raw.worldRank : null,
+    projectedOWGR: typeof raw.projectedOWGR === 'number' ? raw.projectedOWGR : null,
   }
 }

--- a/src/lib/slash-golf/client.ts
+++ b/src/lib/slash-golf/client.ts
@@ -1,4 +1,4 @@
-import type { Tournament, GolferScore, GolferScoreRound } from './types'
+import type { Tournament, GolferScore, GolferScoreRound, SlashTournamentMeta, SlashLeaderboard, SlashGolferStatus } from './types'
 
 const BASE_URL = 'https://live-golf-data.p.rapidapi.com'
 
@@ -243,4 +243,75 @@ function isTournamentMetadataOnlyResponse(raw: unknown): boolean {
     || 'timeZone' in record
     || 'format' in record
   )
+}
+
+function normalizeSlashStatus(value: unknown): SlashGolferStatus {
+  if (typeof value !== 'string') return 'active'
+  const s = value.trim().toLowerCase()
+  if (s === 'withdrawn' || s === 'wd') return 'withdrawn'
+  if (s === 'cut' || s === 'cu') return 'cut'
+  if (s === 'dq') return 'dq'
+  if (s === 'complete' || s === 'finished' || s === 'f') return 'complete'
+  return 'active'
+}
+
+export async function getTournamentMeta(tournamentId: string, year?: number): Promise<SlashTournamentMeta> {
+  const params = new URLSearchParams({ orgId: '1', tournId: tournamentId, ...(year && { year: year.toString() }) })
+  const res = await fetch(`${BASE_URL}/tournament?${params}`, {
+    headers: { 'X-RapidAPI-Key': process.env.SLASH_GOLF_API_KEY ?? '' },
+    next: { revalidate: 3600 }
+  })
+  if (!res.ok) throw new Error('Failed to fetch tournament metadata')
+  const raw = await res.json()
+  return {
+    tournId: typeof raw.tournId === 'string' ? raw.tournId : '',
+    name: typeof raw.name === 'string' ? raw.name : '',
+    year: typeof raw.year === 'string' ? raw.year : (year?.toString() ?? ''),
+    status: typeof raw.status === 'string' ? raw.status : '',
+    currentRound: parseMongoNumber(raw.currentRound) ?? null,
+    courses: Array.isArray(raw.courses) ? raw.courses.map((c: Record<string, unknown>) => ({
+      courseId: typeof c.courseId === 'string' ? c.courseId : '',
+      courseName: typeof c.courseName === 'string' ? c.courseName : '',
+    })) : [],
+    format: typeof raw.format === 'string' ? raw.format : null,
+    date: typeof raw.date === 'string' ? raw.date : null,
+  }
+}
+
+export async function getLeaderboard(tournamentId: string, year?: number): Promise<SlashLeaderboard> {
+  const params = new URLSearchParams({ orgId: '1', tournId: tournamentId, ...(year && { year: year.toString() }) })
+  const res = await fetch(`${BASE_URL}/leaderboard?${params}`, {
+    headers: { 'X-RapidAPI-Key': process.env.SLASH_GOLF_API_KEY ?? '' },
+    cache: 'no-store'
+  })
+  if (!res.ok) throw new Error('Failed to fetch leaderboard')
+  const raw = await res.json()
+  const rows = Array.isArray(raw.leaderboardRows) ? raw.leaderboardRows : []
+  return {
+    tournId: typeof raw.tournId === 'string' ? raw.tournId : '',
+    year: typeof raw.year === 'string' ? raw.year : (year?.toString() ?? ''),
+    status: typeof raw.status === 'string' ? raw.status : '',
+    roundId: parseMongoNumber(raw.roundId) ?? 0,
+    roundStatus: typeof raw.roundStatus === 'string' ? raw.roundStatus : '',
+    timestamp: typeof raw.timestamp === 'string' ? raw.timestamp : '',
+    leaderboardRows: rows.map((row: Record<string, unknown>) => ({
+      playerId: typeof row.playerId === 'string' ? row.playerId : '',
+      lastName: typeof row.lastName === 'string' ? row.lastName : '',
+      firstName: typeof row.firstName === 'string' ? row.firstName : '',
+      isAmateur: typeof row.isAmateur === 'boolean' ? row.isAmateur : false,
+      status: normalizeSlashStatus(row.status),
+      currentRound: parseMongoNumber(row.currentRound) ?? 1,
+      total: typeof row.total === 'string' ? row.total : (typeof row.total === 'object' ? row.total : '0'),
+      currentRoundScore: typeof row.currentRoundScore === 'string' ? row.currentRoundScore : (typeof row.currentRoundScore === 'object' ? row.currentRoundScore : '0'),
+      position: typeof row.position === 'string' ? row.position : null,
+      totalStrokesFromCompletedRounds: typeof row.totalStrokesFromCompletedRounds === 'string' ? row.totalStrokesFromCompletedRounds : null,
+      rounds: Array.isArray(row.rounds) ? row.rounds : [],
+      thru: typeof row.thru === 'string' ? row.thru : null,
+      startingHole: parseMongoNumber(row.startingHole),
+      currentHole: parseMongoNumber(row.currentHole),
+      courseId: typeof row.courseId === 'string' ? row.courseId : null,
+      teeTime: typeof row.teeTime === 'string' ? row.teeTime : null,
+      teeTimeTimestamp: typeof row.teeTimeTimestamp === 'string' ? row.teeTimeTimestamp : null,
+    })),
+  }
 }

--- a/src/lib/slash-golf/types.ts
+++ b/src/lib/slash-golf/types.ts
@@ -48,3 +48,77 @@ export interface RapidApiPlayer {
   country?: string
   worldRank?: number | null
 }
+
+export type SlashGolferStatus = 'active' | 'withdrawn' | 'cut' | 'dq' | 'complete'
+
+export interface SlashTournamentMeta {
+  tournId: string
+  name: string
+  year: string
+  status: string
+  currentRound: number | null
+  courses: Array<{ courseId: string; courseName: string }>
+  format: string | null
+  date: string | null
+}
+
+export interface SlashLeaderboard {
+  tournId: string
+  year: string
+  status: string
+  roundId: number
+  roundStatus: string
+  timestamp: string
+  leaderboardRows: SlashGolferRow[]
+}
+
+export interface SlashGolferRow {
+  playerId: string
+  lastName: string
+  firstName: string
+  isAmateur: boolean
+  status: SlashGolferStatus
+  currentRound: number
+  total: string | { $numberInt: string }
+  currentRoundScore: string | { $numberInt: string }
+  position: string | null
+  totalStrokesFromCompletedRounds: string | null
+  rounds: SlashRound[]
+  thru: string | null
+  startingHole: number | null
+  currentHole: number | null
+  courseId: string | null
+  teeTime: string | null
+  teeTimeTimestamp: string | null
+}
+
+export interface SlashRound {
+  roundId: number
+  courseId: string
+  courseName: string
+  strokes: number | { $numberInt: string }
+  scoreToPar: number | { $numberInt: string }
+}
+
+export interface SlashHole {
+  holeId: number
+  par: number
+  strokes: number
+  scoreToPar: number
+}
+
+export interface SlashScorecard {
+  tournId: string
+  playerId: string
+  year: string
+  status: SlashGolferStatus
+  currentRound: number
+  holes: SlashHole[]
+}
+
+export interface SlashStats {
+  tournId: string
+  playerId: string
+  worldRank: number | null
+  projectedOWGR: number | null
+}

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -2,7 +2,7 @@ export type PoolStatus = 'open' | 'live' | 'complete' | 'archived'
 
 export type PoolFormat = 'best_ball'
 
-export type GolferStatus = 'active' | 'withdrawn' | 'cut'
+export type GolferStatus = 'active' | 'withdrawn' | 'cut' | 'dq' | 'complete'
 export type FreshnessStatus = 'current' | 'stale' | 'unknown'
 
 export type MemberRole = 'commissioner' | 'player'


### PR DESCRIPTION
## Summary

- Added new Slash Golf API types: `SlashTournamentMeta`, `SlashLeaderboard`, `SlashScorecard`, `SlashGolferStatus`, `SlashStats`
- Extended `GolferStatus` in supabase/types.ts to 5-state union (adds `dq`, `complete`)
- Added four new endpoint functions to client.ts: `getTournamentMeta`, `getLeaderboard`, `getScorecard`, `getStats`
- Added `TournamentHole` type and `upsertTournamentHoles` function to scoring-queries.ts
- Created call strategy document at `docs/superpowers/specs/ops-52-call-strategy.md`
- Created fixture stub files for all four Slash Golf endpoints

## Implementation Plan

Implements the plan at: `docs/superpowers/plans/2026-04-27-ops-52-slash-golf-scorecard-driven-scoring-flow-plan.md`

## Design Spec

Design spec at: `docs/superpowers/specs/2026-04-26-ops-52-slash-golf-scorecard-driven-scoring-flow-design.md`

## Verification

```bash
npx tsc --noEmit src/lib/slash-golf/types.ts src/lib/slash-golf/client.ts src/lib/scoring-queries.ts
npx vitest run src/lib/__tests__/slash-golf-client.test.ts src/lib/__tests__/scoring-queries.test.ts
```

All 10 tests passing.

## Commits (7 tasks)

1. `640c487` - OPS-52: add Slash Golf API types
2. `4c5b99f` - OPS-52: extend GolferStatus to 5-state union
3. `9f887f8` - OPS-52: add getTournamentMeta and getLeaderboard endpoint functions
4. `123e7ca` - OPS-52: add getScorecard and getStats endpoint functions
5. `5935962` - OPS-52: add TournamentHole type and upsertTournamentHoles to scoring-queries
6. `838104a` - OPS-52: add call strategy documentation
7. `3d44817` - OPS-52: add fixture stub files for Slash Golf endpoints