### PR TITLE
OPS-58: Fix tsconfig downlevelIteration for Map iteration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],
+    "downlevelIteration": true,
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
Fixes tsconfig.json to enable downlevelIteration, which is required for iterating over Map objects in the scoring engine.