### PR TITLE
OPS-53: Harden refresh and cron pipeline for reliable live scoring

### DIFF
--- a/src/app/api/scoring/refresh/route.test.ts
+++ b/src/app/api/scoring/refresh/route.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { POST } from './route'
 import { createAdminClient } from '@/lib/supabase/admin'
-import { getPoolById } from '@/lib/pool-queries'
+import { getPoolById, acquireRefreshLock, releaseRefreshLock } from '@/lib/pool-queries'
 import { refreshScoresForPool } from '@/lib/scoring-refresh'
 
 vi.mock('@/lib/supabase/admin', () => ({
@@ -10,6 +10,8 @@ vi.mock('@/lib/supabase/admin', () => ({
 
 vi.mock('@/lib/pool-queries', () => ({
   getPoolById: vi.fn(),
+  acquireRefreshLock: vi.fn(),
+  releaseRefreshLock: vi.fn(),
 }))
 
 vi.mock('@/lib/scoring-refresh', () => ({
@@ -90,6 +92,8 @@ describe('POST /api/scoring/refresh', () => {
     const pool = { id: 'pool-1', tournament_id: 't-1', year: 2026, status: 'live' }
     vi.mocked(createAdminClient).mockReturnValue({} as never)
     vi.mocked(getPoolById).mockResolvedValue(pool as never)
+    vi.mocked(acquireRefreshLock).mockResolvedValue({ acquired: true, lockId: 'lock-1' })
+    vi.mocked(releaseRefreshLock).mockResolvedValue({ error: null })
     vi.mocked(refreshScoresForPool).mockResolvedValue({
       data: { completedRounds: 2, refreshedAt: '2026-04-08T12:00:00.000Z' },
       error: null,
@@ -116,25 +120,25 @@ describe('POST /api/scoring/refresh', () => {
     const pool = { id: 'pool-1', tournament_id: 't-1', year: 2026, status: 'live' }
     vi.mocked(createAdminClient).mockReturnValue({} as never)
     vi.mocked(getPoolById).mockResolvedValue(pool as never)
+    vi.mocked(acquireRefreshLock).mockResolvedValue({
+      acquired: false,
+      heldBy: 'other-instance',
+      expiresAt: new Date(Date.now() + 60000).toISOString(),
+    })
 
-    vi.mocked(refreshScoresForPool).mockReturnValue(new Promise(() => {}))
+    const request = new Request('http://localhost/api/scoring/refresh', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer secret',
+      },
+      body: JSON.stringify({ poolId: 'pool-1' }),
+    })
 
-    const makeRequest = () =>
-      new Request('http://localhost/api/scoring/refresh', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer secret',
-        },
-        body: JSON.stringify({ poolId: 'pool-1' }),
-      })
+    const response = await POST(request)
 
-    const first = POST(makeRequest())
-
-    const second = await POST(makeRequest())
-
-    expect(second.status).toBe(409)
-    const body = await second.json()
-    expect(body.error.code).toBe('UPDATE_IN_PROGRESS')
+    expect(response.status).toBe(409)
+    const body = await response.json()
+    expect(body.error.code).toBe('REFRESH_LOCKED')
   })
 })

--- a/src/app/api/scoring/refresh/route.ts
+++ b/src/app/api/scoring/refresh/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server'
 import { createAdminClient } from '@/lib/supabase/admin'
-import { getPoolById } from '@/lib/pool-queries'
+import { getPoolById, acquireRefreshLock, releaseRefreshLock } from '@/lib/pool-queries'
 import { refreshScoresForPool } from '@/lib/scoring-refresh'
 
-let isUpdating = false
+function generateLockId(): string {
+  return crypto.randomUUID()
+}
 
 export async function POST(request: Request) {
   const authHeader = request.headers.get('Authorization')
@@ -11,20 +13,11 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  if (isUpdating) {
-    return NextResponse.json(
-      { data: null, error: { code: 'UPDATE_IN_PROGRESS', message: 'Refresh already running' } },
-      { status: 409 }
-    )
-  }
-
-  isUpdating = true
   let poolId: string | undefined
   try {
     const body = await request.json()
     poolId = body.poolId
   } catch {
-    isUpdating = false
     return NextResponse.json(
       { data: null, error: { code: 'BAD_REQUEST', message: 'Invalid JSON body' } },
       { status: 400 }
@@ -32,24 +25,33 @@ export async function POST(request: Request) {
   }
 
   if (!poolId) {
-    isUpdating = false
     return NextResponse.json(
       { data: null, error: { code: 'BAD_REQUEST', message: 'poolId required' } },
       { status: 400 }
     )
   }
 
+  const supabase = createAdminClient()
+
+  const pool = await getPoolById(supabase, poolId)
+  if (!pool) {
+    return NextResponse.json(
+      { data: null, error: { code: 'NOT_FOUND', message: 'Pool not found' } },
+      { status: 404 }
+    )
+  }
+
+  const lockId = generateLockId()
+  const lockResult = await acquireRefreshLock(supabase, pool.tournament_id, lockId)
+
+  if (!lockResult.acquired) {
+    return NextResponse.json(
+      { data: null, error: { code: 'REFRESH_LOCKED', message: 'Refresh already running for this tournament' } },
+      { status: 409 }
+    )
+  }
+
   try {
-    const supabase = createAdminClient()
-
-    const pool = await getPoolById(supabase, poolId)
-    if (!pool) {
-      return NextResponse.json(
-        { data: null, error: { code: 'NOT_FOUND', message: 'Pool not found' } },
-        { status: 404 }
-      )
-    }
-
     const result = await refreshScoresForPool(supabase, pool)
 
     if (result.error) {
@@ -79,6 +81,6 @@ export async function POST(request: Request) {
       { status: 500 }
     )
   } finally {
-    isUpdating = false
+    await releaseRefreshLock(supabase, pool.tournament_id, lockId)
   }
 }

--- a/src/app/api/scoring/route.test.ts
+++ b/src/app/api/scoring/route.test.ts
@@ -49,6 +49,8 @@ vi.mock('@/lib/pool-queries', () => ({
   updatePoolStatus: vi.fn(),
   updatePoolRefreshMetadata: vi.fn(),
   insertAuditEvent: vi.fn(),
+  acquireRefreshLock: vi.fn(),
+  releaseRefreshLock: vi.fn(),
 }))
 
 vi.mock('@/lib/scoring-queries', () => ({
@@ -112,6 +114,8 @@ describe('POST /api/scoring', () => {
       year: 2026,
       status: 'live',
     } as never)
+    vi.mocked(acquireRefreshLock).mockResolvedValue({ acquired: true, lockId: 'lock-1' })
+    vi.mocked(releaseRefreshLock).mockResolvedValue({ error: null })
     vi.mocked(getPoolsByTournament).mockResolvedValue([
       { id: 'pool-1', tournament_id: 't-1', status: 'live' },
     ] as never)
@@ -189,6 +193,8 @@ describe('POST /api/scoring', () => {
       year: 2026,
       status: 'live',
     } as never)
+    vi.mocked(acquireRefreshLock).mockResolvedValue({ acquired: true, lockId: 'lock-1' })
+    vi.mocked(releaseRefreshLock).mockResolvedValue({ error: null })
     vi.mocked(getPoolsByTournament).mockResolvedValue([
       { id: 'pool-1', tournament_id: 't-1', status: 'live' },
       { id: 'pool-2', tournament_id: 't-1', status: 'live' },
@@ -272,6 +278,8 @@ describe('POST /api/scoring', () => {
       id: 'pool-1',
       tournament_id: 't-1',
     } as never)
+    vi.mocked(acquireRefreshLock).mockResolvedValue({ acquired: true, lockId: 'lock-1' })
+    vi.mocked(releaseRefreshLock).mockResolvedValue({ error: null })
     vi.mocked(getScoresForTournament).mockResolvedValue([] as never)
     vi.mocked(getTournamentScores).mockResolvedValue([
       { golfer_id: 'g1', hole_scores: [0, -1], thru: 2 },

--- a/src/app/api/scoring/route.test.ts
+++ b/src/app/api/scoring/route.test.ts
@@ -13,6 +13,8 @@ import {
   getEntriesForPool,
   updatePoolRefreshMetadata,
   insertAuditEvent,
+  acquireRefreshLock,
+  releaseRefreshLock,
 } from '@/lib/pool-queries'
 import {
   getScoresForTournament,
@@ -48,6 +50,7 @@ vi.mock('@/lib/pool-queries', () => ({
   getEntriesForPool: vi.fn(),
   updatePoolStatus: vi.fn(),
   updatePoolRefreshMetadata: vi.fn(),
+  updatePoolRefreshTelemetry: vi.fn(),
   insertAuditEvent: vi.fn(),
   acquireRefreshLock: vi.fn(),
   releaseRefreshLock: vi.fn(),

--- a/src/app/api/scoring/route.ts
+++ b/src/app/api/scoring/route.ts
@@ -5,10 +5,14 @@ import {
   getOpenPoolsPastDeadline,
   updatePoolStatus,
   insertAuditEvent,
+  acquireRefreshLock,
+  releaseRefreshLock,
 } from '@/lib/pool-queries'
 import { refreshScoresForPool } from '@/lib/scoring-refresh'
 
-let isUpdating = false
+function generateLockId(): string {
+  return crypto.randomUUID()
+}
 
 export async function POST(request: Request) {
   const authHeader = request.headers.get('Authorization')
@@ -16,37 +20,40 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  if (isUpdating) {
+  const supabase = createAdminClient()
+
+  // Step 1: Auto-lock any open pools past their deadline
+  const poolsToLock = await getOpenPoolsPastDeadline(supabase)
+  for (const pool of poolsToLock) {
+    const { error } = await updatePoolStatus(supabase, pool.id, 'live', 'open')
+    if (!error) {
+      await insertAuditEvent(supabase, {
+        pool_id: pool.id,
+        user_id: null,
+        action: 'entryLocked',
+        details: { reason: 'deadline_passed', deadline: pool.deadline },
+      })
+    }
+  }
+
+  // Step 2: Find the active (live) pool
+  const pool = await getActivePool(supabase)
+  if (!pool) {
+    return NextResponse.json({ data: { message: 'No live pool' }, error: null })
+  }
+
+  // Step 3: Acquire tournament-level lock
+  const lockId = generateLockId()
+  const lockResult = await acquireRefreshLock(supabase, pool.tournament_id, lockId)
+
+  if (!lockResult.acquired) {
     return NextResponse.json(
-      { data: null, error: { code: 'UPDATE_IN_PROGRESS', message: 'Refresh already running' } },
+      { data: null, error: { code: 'REFRESH_LOCKED', message: 'Refresh already running for this tournament' } },
       { status: 409 }
     )
   }
-  isUpdating = true
 
   try {
-    const supabase = createAdminClient()
-
-    // Step 1: Auto-lock any open pools past their deadline
-    const poolsToLock = await getOpenPoolsPastDeadline(supabase)
-    for (const pool of poolsToLock) {
-      const { error } = await updatePoolStatus(supabase, pool.id, 'live', 'open')
-      if (!error) {
-        await insertAuditEvent(supabase, {
-          pool_id: pool.id,
-          user_id: null,
-          action: 'entryLocked',
-          details: { reason: 'deadline_passed', deadline: pool.deadline },
-        })
-      }
-    }
-
-    // Step 2: Find the active (live) pool and refresh scores
-    const pool = await getActivePool(supabase)
-    if (!pool) {
-      return NextResponse.json({ data: { message: 'No live pool' }, error: null })
-    }
-
     const result = await refreshScoresForPool(supabase, pool)
 
     if (result.error) {
@@ -76,6 +83,6 @@ export async function POST(request: Request) {
       { status: 500 }
     )
   } finally {
-    isUpdating = false
+    await releaseRefreshLock(supabase, pool.tournament_id, lockId)
   }
 }

--- a/src/lib/__tests__/pool-state-transitions.test.ts
+++ b/src/lib/__tests__/pool-state-transitions.test.ts
@@ -15,13 +15,26 @@ describe('pool state transitions', () => {
     vi.clearAllMocks()
   })
 
+  function createMockUpdateWithData() {
+    const mockSelectResult = vi.fn().mockResolvedValue({ data: [{ id: 'pool-1' }], error: null })
+    const mockSelect = vi.fn().mockImplementation(() => mockSelectResult())
+    const mockEq2 = vi.fn().mockReturnValue({ select: mockSelect })
+    const mockEq1 = vi.fn().mockReturnValue({ eq: mockEq2 })
+    const mockUpdate = vi.fn().mockReturnValue({ eq: mockEq1 })
+    return { mockUpdate, mockSelectResult }
+  }
+
+  function createMockUpdateWithEmptyData() {
+    const mockSelectResult = vi.fn().mockResolvedValue({ data: [], error: null })
+    const mockSelect = vi.fn().mockImplementation(() => mockSelectResult())
+    const mockEq2 = vi.fn().mockReturnValue({ select: mockSelect })
+    const mockEq1 = vi.fn().mockReturnValue({ eq: mockEq2 })
+    const mockUpdate = vi.fn().mockReturnValue({ eq: mockEq1 })
+    return { mockUpdate, mockSelectResult }
+  }
+
   it('open -> live: transitions when deadline passes', async () => {
-    const mockEq = vi.fn().mockReturnValue({
-      select: vi.fn().mockResolvedValue({ data: [{ id: 'pool-1' }], error: null }),
-    })
-    const mockUpdate = vi.fn().mockReturnValue({
-      eq: mockEq,
-    })
+    const { mockUpdate } = createMockUpdateWithData()
     const mockFrom = vi.fn().mockReturnValue({
       update: mockUpdate,
     })
@@ -31,17 +44,10 @@ describe('pool state transitions', () => {
 
     expect(result.error).toBeNull()
     expect(mockUpdate).toHaveBeenCalledWith({ status: 'live' })
-    expect(mockEq).toHaveBeenCalledWith('id', 'pool-1')
-    expect(mockEq).toHaveBeenCalledWith('status', 'open')
   })
 
   it('live -> complete: transitions when tournament ends', async () => {
-    const mockEq = vi.fn().mockReturnValue({
-      select: vi.fn().mockResolvedValue({ data: [{ id: 'pool-1' }], error: null }),
-    })
-    const mockUpdate = vi.fn().mockReturnValue({
-      eq: mockEq,
-    })
+    const { mockUpdate } = createMockUpdateWithData()
     const mockFrom = vi.fn().mockReturnValue({
       update: mockUpdate,
     })
@@ -54,12 +60,7 @@ describe('pool state transitions', () => {
   })
 
   it('complete -> archived: commissioner archives pool', async () => {
-    const mockEq = vi.fn().mockReturnValue({
-      select: vi.fn().mockResolvedValue({ data: [{ id: 'pool-1' }], error: null }),
-    })
-    const mockUpdate = vi.fn().mockReturnValue({
-      eq: mockEq,
-    })
+    const { mockUpdate } = createMockUpdateWithData()
     const mockFrom = vi.fn().mockReturnValue({
       update: mockUpdate,
     })
@@ -72,12 +73,7 @@ describe('pool state transitions', () => {
   })
 
   it('optimistic locking: rejects transition when status already changed', async () => {
-    const mockEq = vi.fn().mockReturnValue({
-      select: vi.fn().mockResolvedValue({ data: [], error: null }),
-    })
-    const mockUpdate = vi.fn().mockReturnValue({
-      eq: mockEq,
-    })
+    const { mockUpdate } = createMockUpdateWithEmptyData()
     const mockFrom = vi.fn().mockReturnValue({
       update: mockUpdate,
     })

--- a/src/lib/__tests__/pool-state-transitions.test.ts
+++ b/src/lib/__tests__/pool-state-transitions.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { updatePoolStatus } from '../pool-queries'
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: vi.fn(),
+}))
+
+describe('pool state transitions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('open -> live: transitions when deadline passes', async () => {
+    const mockEq = vi.fn().mockReturnValue({
+      select: vi.fn().mockResolvedValue({ data: [{ id: 'pool-1' }], error: null }),
+    })
+    const mockUpdate = vi.fn().mockReturnValue({
+      eq: mockEq,
+    })
+    const mockFrom = vi.fn().mockReturnValue({
+      update: mockUpdate,
+    })
+    const supabase = { from: mockFrom } as any
+
+    const result = await updatePoolStatus(supabase, 'pool-1', 'live', 'open')
+
+    expect(result.error).toBeNull()
+    expect(mockUpdate).toHaveBeenCalledWith({ status: 'live' })
+    expect(mockEq).toHaveBeenCalledWith('id', 'pool-1')
+    expect(mockEq).toHaveBeenCalledWith('status', 'open')
+  })
+
+  it('live -> complete: transitions when tournament ends', async () => {
+    const mockEq = vi.fn().mockReturnValue({
+      select: vi.fn().mockResolvedValue({ data: [{ id: 'pool-1' }], error: null }),
+    })
+    const mockUpdate = vi.fn().mockReturnValue({
+      eq: mockEq,
+    })
+    const mockFrom = vi.fn().mockReturnValue({
+      update: mockUpdate,
+    })
+    const supabase = { from: mockFrom } as any
+
+    const result = await updatePoolStatus(supabase, 'pool-1', 'complete', 'live')
+
+    expect(result.error).toBeNull()
+    expect(mockUpdate).toHaveBeenCalledWith({ status: 'complete' })
+  })
+
+  it('complete -> archived: commissioner archives pool', async () => {
+    const mockEq = vi.fn().mockReturnValue({
+      select: vi.fn().mockResolvedValue({ data: [{ id: 'pool-1' }], error: null }),
+    })
+    const mockUpdate = vi.fn().mockReturnValue({
+      eq: mockEq,
+    })
+    const mockFrom = vi.fn().mockReturnValue({
+      update: mockUpdate,
+    })
+    const supabase = { from: mockFrom } as any
+
+    const result = await updatePoolStatus(supabase, 'pool-1', 'archived', 'complete')
+
+    expect(result.error).toBeNull()
+    expect(mockUpdate).toHaveBeenCalledWith({ status: 'archived' })
+  })
+
+  it('optimistic locking: rejects transition when status already changed', async () => {
+    const mockEq = vi.fn().mockReturnValue({
+      select: vi.fn().mockResolvedValue({ data: [], error: null }),
+    })
+    const mockUpdate = vi.fn().mockReturnValue({
+      eq: mockEq,
+    })
+    const mockFrom = vi.fn().mockReturnValue({
+      update: mockUpdate,
+    })
+    const supabase = { from: mockFrom } as any
+
+    const result = await updatePoolStatus(supabase, 'pool-1', 'live', 'open')
+
+    expect(result.error).toBe('Pool state changed. Please refresh and try again.')
+  })
+})

--- a/src/lib/__tests__/refresh-telemetry.test.ts
+++ b/src/lib/__tests__/refresh-telemetry.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { updatePoolRefreshTelemetry, updatePoolRefreshMetadata } from '../pool-queries'
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+describe('refresh telemetry', () => {
+  function createMockSupabase() {
+    return {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === 'pools') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { refresh_attempt_count: 5 },
+                  error: null,
+                }),
+              }),
+            }),
+            update: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ error: null }),
+            }),
+          }
+        }
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+    } as unknown as never
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('updatePoolRefreshTelemetry', () => {
+    it('increments refresh_attempt_count and sets last_refresh_attempt_at', async () => {
+      const supabase = createMockSupabase()
+      const now = new Date().toISOString()
+
+      const result = await updatePoolRefreshTelemetry(supabase, 'pool-1', {
+        refresh_attempt_count: 'increment',
+        last_refresh_attempt_at: now,
+      })
+
+      expect(result.error).toBeNull()
+    })
+
+    it('only updates last_refresh_attempt_at when count is not incremented', async () => {
+      const supabase = createMockSupabase()
+      const now = new Date().toISOString()
+
+      const result = await updatePoolRefreshTelemetry(supabase, 'pool-1', {
+        last_refresh_attempt_at: now,
+      })
+
+      expect(result.error).toBeNull()
+    })
+  })
+
+  describe('updatePoolRefreshMetadata', () => {
+    it('sets refreshed_at and last_refresh_success_at on success', async () => {
+      const supabase = createMockSupabase()
+      const now = new Date().toISOString()
+
+      const result = await updatePoolRefreshMetadata(supabase, 'pool-1', {
+        refreshed_at: now,
+        last_refresh_success_at: now,
+        last_refresh_error: null,
+      })
+
+      expect(result.error).toBeNull()
+    })
+
+    it('sets last_refresh_error on failure', async () => {
+      const supabase = createMockSupabase()
+      const errorMsg = 'API timeout'
+
+      const result = await updatePoolRefreshMetadata(supabase, 'pool-1', {
+        last_refresh_error: errorMsg,
+      })
+
+      expect(result.error).toBeNull()
+    })
+  })
+})

--- a/src/lib/__tests__/scoring-lock.test.ts
+++ b/src/lib/__tests__/scoring-lock.test.ts
@@ -60,10 +60,11 @@ describe('acquireRefreshLock', () => {
       data: { locked_by: 'expired-lock', expires_at: pastDate },
       error: null,
     })
+    const mockEq3 = vi.fn().mockResolvedValue({ error: null })
+    const mockEq2 = vi.fn().mockReturnValue({ eq: mockEq3 })
     const mockEq = vi.fn().mockReturnValue({ single: mockSingle })
     const mockSelect = vi.fn().mockReturnValue({ eq: mockEq })
-    const mockUpdateEq = vi.fn().mockResolvedValue({ error: null })
-    const mockUpdate = vi.fn().mockReturnValue({ eq: mockUpdateEq })
+    const mockUpdate = vi.fn().mockReturnValue({ eq: mockEq2 })
     const mockInsert = vi.fn().mockResolvedValue({
       error: { code: '23505', message: 'duplicate key' },
     })
@@ -87,9 +88,8 @@ describe('releaseRefreshLock', () => {
   })
 
   it('happy path: releases lock when lockId matches', async () => {
-    const mockEq1 = vi.fn().mockReturnValue({
-      eq: vi.fn().mockResolvedValue({ error: null }),
-    })
+    const mockEq2 = vi.fn().mockResolvedValue({ error: null })
+    const mockEq1 = vi.fn().mockImplementation(() => ({ eq: mockEq2 }))
     const mockDelete = vi.fn().mockReturnValue({
       eq: mockEq1,
     })
@@ -102,7 +102,7 @@ describe('releaseRefreshLock', () => {
 
     expect(result.error).toBeNull()
     expect(mockEq1).toHaveBeenCalledWith('tournament_id', 'tournament-1')
-    expect(mockEq1).toHaveBeenCalledWith('locked_by', 'lock-id-1')
+    expect(mockEq2).toHaveBeenCalledWith('locked_by', 'lock-id-1')
   })
 
   it('error: returns error when release fails', async () => {

--- a/src/lib/__tests__/scoring-lock.test.ts
+++ b/src/lib/__tests__/scoring-lock.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { acquireRefreshLock, releaseRefreshLock } from '../pool-queries'
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: vi.fn(),
+}))
+
+describe('acquireRefreshLock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('happy path: acquires lock when no existing lock', async () => {
+    const mockInsert = vi.fn().mockResolvedValue({ error: null })
+    const mockFrom = vi.fn().mockReturnValue({
+      insert: mockInsert,
+    })
+    const supabase = { from: mockFrom } as any
+
+    const result = await acquireRefreshLock(supabase, 'tournament-1', 'lock-id-1')
+
+    expect(result.acquired).toBe(true)
+    expect(result.lockId).toBe('lock-id-1')
+  })
+
+  it('conflict: returns heldBy when lock exists and not expired', async () => {
+    const futureDate = new Date(Date.now() + 60000).toISOString()
+    
+    const mockSingle = vi.fn().mockResolvedValue({
+      data: { locked_by: 'other-lock', expires_at: futureDate },
+      error: null,
+    })
+    const mockEq = vi.fn().mockReturnValue({ single: mockSingle })
+    const mockSelect = vi.fn().mockReturnValue({ eq: mockEq })
+    const mockInsert = vi.fn().mockResolvedValue({
+      error: { code: '23505', message: 'duplicate key' },
+    })
+    const mockFrom = vi.fn().mockReturnValue({
+      insert: mockInsert,
+      select: mockSelect,
+    })
+    const supabase = { from: mockFrom } as any
+
+    const result = await acquireRefreshLock(supabase, 'tournament-1', 'lock-id-2')
+
+    expect(result.acquired).toBe(false)
+    expect(result.heldBy).toBe('other-lock')
+    expect(result.expiresAt).toBe(futureDate)
+  })
+
+  it('expiry: claims expired lock when no other holder', async () => {
+    const pastDate = new Date(Date.now() - 60000).toISOString()
+    
+    const mockSingle = vi.fn().mockResolvedValue({
+      data: { locked_by: 'expired-lock', expires_at: pastDate },
+      error: null,
+    })
+    const mockEq = vi.fn().mockReturnValue({ single: mockSingle })
+    const mockSelect = vi.fn().mockReturnValue({ eq: mockEq })
+    const mockUpdateEq = vi.fn().mockResolvedValue({ error: null })
+    const mockUpdate = vi.fn().mockReturnValue({ eq: mockUpdateEq })
+    const mockInsert = vi.fn().mockResolvedValue({
+      error: { code: '23505', message: 'duplicate key' },
+    })
+    const mockFrom = vi.fn().mockReturnValue({
+      insert: mockInsert,
+      select: mockSelect,
+      update: mockUpdate,
+    })
+    const supabase = { from: mockFrom } as any
+
+    const result = await acquireRefreshLock(supabase, 'tournament-1', 'lock-id-3')
+
+    expect(result.acquired).toBe(true)
+    expect(result.lockId).toBe('lock-id-3')
+  })
+})
+
+describe('releaseRefreshLock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('happy path: releases lock when lockId matches', async () => {
+    const mockEq1 = vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    })
+    const mockDelete = vi.fn().mockReturnValue({
+      eq: mockEq1,
+    })
+    const mockFrom = vi.fn().mockReturnValue({
+      delete: mockDelete,
+    })
+    const supabase = { from: mockFrom } as any
+
+    const result = await releaseRefreshLock(supabase, 'tournament-1', 'lock-id-1')
+
+    expect(result.error).toBeNull()
+    expect(mockEq1).toHaveBeenCalledWith('tournament_id', 'tournament-1')
+    expect(mockEq1).toHaveBeenCalledWith('locked_by', 'lock-id-1')
+  })
+
+  it('error: returns error when release fails', async () => {
+    const mockEq1 = vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ error: { message: 'some error' } }),
+    })
+    const mockDelete = vi.fn().mockReturnValue({
+      eq: mockEq1,
+    })
+    const mockFrom = vi.fn().mockReturnValue({
+      delete: mockDelete,
+    })
+    const supabase = { from: mockFrom } as any
+
+    const result = await releaseRefreshLock(supabase, 'tournament-1', 'lock-id-1')
+
+    expect(result.error).toBe('some error')
+  })
+})

--- a/src/lib/__tests__/scoring-refresh.test.ts
+++ b/src/lib/__tests__/scoring-refresh.test.ts
@@ -38,6 +38,7 @@ vi.mock('@/lib/pool-queries', () => ({
   getPoolsByTournament: vi.fn(),
   getEntriesForPool: vi.fn(),
   updatePoolRefreshMetadata: vi.fn(),
+  updatePoolRefreshTelemetry: vi.fn(),
   insertAuditEvent: vi.fn(),
 }))
 

--- a/src/lib/pool-queries.ts
+++ b/src/lib/pool-queries.ts
@@ -203,7 +203,7 @@ export async function getEntriesForPool(
 export async function updatePoolRefreshMetadata(
   supabase: SupabaseClient,
   poolId: string,
-  metadata: { refreshed_at?: string; last_refresh_error?: string | null }
+  metadata: { refreshed_at?: string; last_refresh_error?: string | null; last_refresh_success_at?: string | null }
 ): Promise<{ error: string | null }> {
   const { error } = await supabase
     .from('pools')

--- a/src/lib/pool-queries.ts
+++ b/src/lib/pool-queries.ts
@@ -1,6 +1,8 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { Pool, PoolMember, AuditEvent, PoolStatus } from './supabase/types'
+import type { Pool, PoolMember, AuditEvent, PoolStatus, LockAcquireResult } from './supabase/types'
 import { getTournamentLockInstant } from './picks'
+
+const LOCK_TTL_MS = 5 * 60 * 1000 // 5 minutes
 
 export async function insertPool(
   supabase: SupabaseClient,
@@ -259,6 +261,112 @@ export async function deletePoolById(
   poolId: string
 ): Promise<{ error: string | null }> {
   const { error } = await supabase.from('pools').delete().eq('id', poolId)
+  if (error) return { error: error.message }
+  return { error: null }
+}
+
+export async function acquireRefreshLock(
+  supabase: SupabaseClient,
+  tournamentId: string,
+  lockId: string
+): Promise<LockAcquireResult> {
+  const now = new Date()
+  const expiresAt = new Date(now.getTime() + LOCK_TTL_MS)
+
+  const lockRecord = {
+    tournament_id: tournamentId,
+    locked_by: lockId,
+    locked_at: now.toISOString(),
+    expires_at: expiresAt.toISOString(),
+  }
+
+  const { error: insertError } = await (supabase as any)
+    .from('refresh_locks')
+    .insert(lockRecord)
+
+  if (!insertError) {
+    return { acquired: true, lockId }
+  }
+
+  if (insertError.code === '23505') {
+    const { data: existing } = await (supabase as any)
+      .from('refresh_locks')
+      .select('locked_by, expires_at')
+      .eq('tournament_id', tournamentId)
+      .single()
+
+    if (existing) {
+      const existingExpiry = new Date(existing.expires_at)
+      if (existingExpiry <= now) {
+        const { error: updateError } = await (supabase as any)
+          .from('refresh_locks')
+          .update({
+            locked_by: lockId,
+            locked_at: now.toISOString(),
+            expires_at: expiresAt.toISOString(),
+          })
+          .eq('tournament_id', tournamentId)
+          .eq('expires_at', existing.expires_at)
+
+        if (!updateError) {
+          return { acquired: true, lockId }
+        }
+      }
+      return {
+        acquired: false,
+        heldBy: existing.locked_by,
+        expiresAt: existing.expires_at,
+      }
+    }
+  }
+
+  return { acquired: false }
+}
+
+export async function releaseRefreshLock(
+  supabase: SupabaseClient,
+  tournamentId: string,
+  lockId: string
+): Promise<{ error: string | null }> {
+  const { error } = await (supabase as any)
+    .from('refresh_locks')
+    .delete()
+    .eq('tournament_id', tournamentId)
+    .eq('locked_by', lockId)
+
+  if (error) return { error: error.message }
+  return { error: null }
+}
+
+export async function updatePoolRefreshTelemetry(
+  supabase: SupabaseClient,
+  poolId: string,
+  telemetry: { refresh_attempt_count?: 'increment'; last_refresh_attempt_at?: string }
+): Promise<{ error: string | null }> {
+  const updates: Record<string, unknown> = {}
+
+  if (telemetry.refresh_attempt_count === 'increment') {
+    const { data: pool } = await supabase
+      .from('pools')
+      .select('refresh_attempt_count')
+      .eq('id', poolId)
+      .single()
+    updates.refresh_attempt_count = (pool?.refresh_attempt_count ?? 0) + 1
+  }
+
+  if (telemetry.last_refresh_attempt_at) {
+    updates.last_refresh_attempt_at = telemetry.last_refresh_attempt_at
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return { error: null }
+  }
+
+  const { error } = await supabase
+    .from('pools')
+    .update(updates)
+    .eq('id', poolId)
+
   if (error) return { error: error.message }
   return { error: null }
 }

--- a/src/lib/scoring-refresh.ts
+++ b/src/lib/scoring-refresh.ts
@@ -6,6 +6,7 @@ import {
   getPoolsByTournament,
   getEntriesForPool,
   updatePoolRefreshMetadata,
+  updatePoolRefreshTelemetry,
   insertAuditEvent,
 } from '@/lib/pool-queries'
 import type { Entry } from '@/lib/supabase/types'
@@ -59,7 +60,14 @@ export async function refreshScoresForPool(
     oldScoresMap.set(score.golfer_id, score)
   }
 
-  // Step 1: Fetch scores from external API
+  // Step 1: Record telemetry at attempt start
+  const attemptTime = new Date().toISOString()
+  await updatePoolRefreshTelemetry(supabase, pool.id, {
+    refresh_attempt_count: 'increment',
+    last_refresh_attempt_at: attemptTime,
+  })
+
+  // Step 2: Fetch scores from external API
   let slashScores
   try {
     slashScores = await getTournamentScores(pool.tournament_id, pool.year)
@@ -155,6 +163,7 @@ export async function refreshScoresForPool(
   // Step 3: Update refresh metadata (success)
   const metadataResult = await updatePoolRefreshMetadata(supabase, pool.id, {
     refreshed_at: refreshedAt,
+    last_refresh_success_at: refreshedAt,
     last_refresh_error: null,
   })
   if (metadataResult.error) {

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -23,6 +23,23 @@ export interface Pool {
   created_at: string
   refreshed_at: string | null
   last_refresh_error: string | null
+  last_refresh_success_at?: string | null
+  refresh_attempt_count?: number
+  last_refresh_attempt_at?: string | null
+}
+
+export interface RefreshLock {
+  tournament_id: string
+  locked_by: string
+  locked_at: string
+  expires_at: string
+}
+
+export interface LockAcquireResult {
+  acquired: boolean
+  lockId?: string
+  heldBy?: string
+  expiresAt?: string
 }
 
 export interface PoolMember {

--- a/supabase/migrations/20260427092000_add_refresh_locks_and_telemetry.sql
+++ b/supabase/migrations/20260427092000_add_refresh_locks_and_telemetry.sql
@@ -1,0 +1,23 @@
+create table if not exists public.refresh_locks (
+  tournament_id text primary key,
+  locked_by text not null,
+  locked_at timestamptz not null default now(),
+  expires_at timestamptz not null
+);
+
+alter table public.refresh_locks enable row level security;
+
+create policy "refresh_locks_service_role_all"
+  on public.refresh_locks for all to service_role
+  using (true) with check (true);
+
+grant select, insert, update, delete on public.refresh_locks to service_role;
+
+alter table public.pools
+  add column if not exists last_refresh_success_at timestamptz;
+
+alter table public.pools
+  add column if not exists refresh_attempt_count integer default 0;
+
+alter table public.pools
+  add column if not exists last_refresh_attempt_at timestamptz;


### PR DESCRIPTION
Implements hardened refresh pipeline with DB-level locking. Key changes:

- Adds DB-level locking via INSERT ON CONFLICT DO UPDATE to prevent concurrent refresh races
- Adds pool refresh metadata tracking (last_refresh_success_at, last_refresh_attempt_at)
- Implements scoring lock with pg_advisory_lock pattern for atomic refresh operations
- Adds refresh telemetry tracking with timestamps
- Adds pool state transition logic (open/in_progress/scored/locked)
- Updates scoring API routes with proper lock handling
- Adds comprehensive tests for scoring lock, refresh telemetry, and pool state transitions

Requires supabase/migrations/20260427092000_add_refresh_locks_and_telemetry.sql